### PR TITLE
Harden workload recovery and inspection rendering

### DIFF
--- a/Source/Better Work Tab.csproj
+++ b/Source/Better Work Tab.csproj
@@ -170,8 +170,10 @@
     <Compile Include="Features\Workloads\V2\WorkloadCanonical.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadDefinition.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadDiff.cs" />
+    <Compile Include="Features\Workloads\V2\WorkloadInspectionSemantics.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadKeys.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadMembership.cs" />
+    <Compile Include="Features\Workloads\V2\Runtime\WorkloadPersistenceReceiptRecovery.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadScope.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadSession.cs" />
     <Compile Include="Features\Workloads\V2\WorkloadState.cs" />

--- a/Source/Features/Workloads/V2/Runtime/Workload2Backend.cs
+++ b/Source/Features/Workloads/V2/Runtime/Workload2Backend.cs
@@ -1397,7 +1397,8 @@ namespace Better_Work_Tab.Features.Workloads.V2.Runtime
 
         internal WorkloadOperationResult<WorkloadPersistenceReceipt> RecoverPersistenceReceipt(
             WorkloadDecisionKind decisionKind,
-            string targetStableId)
+            string targetStableId,
+            string forkLabel)
         {
             if (_previewSession == null)
             {
@@ -1409,7 +1410,8 @@ namespace Better_Work_Tab.Features.Workloads.V2.Runtime
             return _applyService.RecoverPersistenceReceipt(
                 _previewSession,
                 decisionKind,
-                targetStableId);
+                targetStableId,
+                forkLabel);
         }
 
         internal WorkloadOperationResult<WorkloadSession> BuildMultiplayerSession(
@@ -2880,7 +2882,8 @@ namespace Better_Work_Tab.Features.Workloads.V2.Runtime
         internal WorkloadOperationResult<WorkloadPersistenceReceipt> RecoverPersistenceReceipt(
             WorkloadSession session,
             WorkloadDecisionKind decisionKind,
-            string targetStableId)
+            string targetStableId,
+            string forkLabel)
         {
             if (session == null || session.SourceTemplate == null ||
                 session.SourceTemplate.Definition == null)
@@ -2964,52 +2967,18 @@ namespace Better_Work_Tab.Features.Workloads.V2.Runtime
                 return receipt;
             }
 
-            string expectedTargetIdentity =
-                WorkloadSession.GetSourceIdentity(session.TargetTemplate);
-            if (!StringComparer.Ordinal.Equals(
-                    receipt.Value.TargetIdentity,
-                    expectedTargetIdentity))
-            {
-                return WorkloadOperationResult<WorkloadPersistenceReceipt>.Fail(
-                    WorkloadDiagnosticCode.PersistenceConflict,
-                    "The current V2 target identity is stale relative to the active preview.");
-            }
-
-            int expectedRevision = baseline.PersistenceRevision;
-            bool requiresPostWriteRevision = decisionKind == WorkloadDecisionKind.Fork ||
-                !StringComparer.Ordinal.Equals(
-                    receipt.Value.TargetIdentity,
-                    sourceIdentity);
-            if (requiresPostWriteRevision)
-            {
-                if (expectedRevision == int.MaxValue)
-                {
-                    return WorkloadOperationResult<WorkloadPersistenceReceipt>.Fail(
-                        WorkloadDiagnosticCode.PersistenceConflict,
-                        "The V2 persistence revision cannot prove the recovered write.");
-                }
-
-                expectedRevision++;
-            }
-
-            if (receipt.Value.PersistenceRevision != expectedRevision)
-            {
-                return WorkloadOperationResult<WorkloadPersistenceReceipt>.Fail(
-                    WorkloadDiagnosticCode.PersistenceConflict,
-                    "The current V2 persistence revision is not the authoritative post-write revision.");
-            }
-
-            if (decisionKind == WorkloadDecisionKind.Fork &&
-                !StringComparer.Ordinal.Equals(
-                    receipt.Value.CurrentWorkloadId,
-                    targetStableId))
-            {
-                return WorkloadOperationResult<WorkloadPersistenceReceipt>.Fail(
-                    WorkloadDiagnosticCode.PersistenceConflict,
-                    "The recovered V2 Fork target is not the current workload.");
-            }
-
-            return receipt;
+            return WorkloadPersistenceReceiptRecovery.TryRecover(
+                session,
+                decisionKind,
+                targetStableId,
+                forkLabel,
+                baseline.PersistenceRevision,
+                baseline.PersistenceFingerprint,
+                new WorkloadPersistenceRecoverySnapshot(
+                    receipt.Value.TargetTemplate,
+                    receipt.Value.PersistenceRevision,
+                    receipt.Value.PersistenceFingerprint,
+                    receipt.Value.CurrentWorkloadId));
         }
 
         internal WorkloadOperationResult<WorkloadProjectedState> CaptureLiveBaseline(

--- a/Source/Features/Workloads/V2/Runtime/WorkloadPersistenceReceiptRecovery.cs
+++ b/Source/Features/Workloads/V2/Runtime/WorkloadPersistenceReceiptRecovery.cs
@@ -1,0 +1,198 @@
+using System;
+using Better_Work_Tab.Features.Workloads.V2;
+
+namespace Better_Work_Tab.Features.Workloads.V2.Runtime
+{
+    /// <summary>
+    /// Immutable persistence data captured after a store round-trip. The
+    /// backend supplies this only after it has verified the authoritative
+    /// record and store fingerprint; the recovery seam itself remains pure.
+    /// </summary>
+    internal sealed class WorkloadPersistenceRecoverySnapshot
+    {
+        internal WorkloadPersistenceRecoverySnapshot(
+            WorkloadTemplate targetTemplate,
+            int persistenceRevision,
+            string persistenceFingerprint,
+            string currentWorkloadId)
+        {
+            TargetTemplate = targetTemplate;
+            PersistenceRevision = persistenceRevision;
+            PersistenceFingerprint = persistenceFingerprint ?? string.Empty;
+            CurrentWorkloadId = currentWorkloadId ?? string.Empty;
+        }
+
+        internal WorkloadTemplate TargetTemplate { get; private set; }
+        internal int PersistenceRevision { get; private set; }
+        internal string PersistenceFingerprint { get; private set; }
+        internal string CurrentWorkloadId { get; private set; }
+    }
+
+    /// <summary>
+    /// Pure, fail-closed construction of a recovery receipt from an
+    /// authoritative persistence snapshot. No session, store, or baseline is
+    /// mutated here; the caller must apply the resulting receipt only after
+    /// its own backend rekey/round-trip checks succeed.
+    /// </summary>
+    internal static class WorkloadPersistenceReceiptRecovery
+    {
+        internal static WorkloadOperationResult<WorkloadPersistenceReceipt> TryRecover(
+            WorkloadSession session,
+            WorkloadDecisionKind decisionKind,
+            string targetStableId,
+            string forkLabel,
+            int previousPersistenceRevision,
+            string previousPersistenceFingerprint,
+            WorkloadPersistenceRecoverySnapshot snapshot)
+        {
+            if (session == null || session.SourceTemplate == null ||
+                session.SourceTemplate.Definition == null || snapshot == null ||
+                snapshot.TargetTemplate == null ||
+                snapshot.TargetTemplate.Definition == null)
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.InvalidState,
+                    "The V2 persistence receipt recovery inputs are incomplete.");
+            }
+
+            if (decisionKind != WorkloadDecisionKind.Update &&
+                decisionKind != WorkloadDecisionKind.Fork)
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.UnsupportedOperation,
+                    "A V2 persistence receipt can only be recovered for Update or Fork.");
+            }
+
+            string sourceStableId = session.SourceTemplate.StableId ?? string.Empty;
+            string sourceIdentity = session.SourceIdentity ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(sourceStableId) ||
+                string.IsNullOrWhiteSpace(sourceIdentity) ||
+                !StringComparer.Ordinal.Equals(
+                    sourceIdentity,
+                    WorkloadSession.GetSourceIdentity(session.SourceTemplate)))
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.PersistenceConflict,
+                    "The V2 preview source identity is stale or unavailable for persistence receipt recovery.");
+            }
+
+            string safeTargetStableId = targetStableId ?? string.Empty;
+            if (decisionKind == WorkloadDecisionKind.Update)
+            {
+                if (!StringComparer.Ordinal.Equals(safeTargetStableId, sourceStableId))
+                {
+                    return Fail(
+                        WorkloadDiagnosticCode.InvalidState,
+                        "The V2 Update receipt target does not match the active preview source.");
+                }
+            }
+            else if (string.IsNullOrWhiteSpace(safeTargetStableId) ||
+                     StringComparer.Ordinal.Equals(safeTargetStableId, sourceStableId))
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.InvalidState,
+                    "The V2 Fork receipt target is missing or reuses the preview source ID.");
+            }
+
+            if (previousPersistenceRevision < 0 ||
+                string.IsNullOrWhiteSpace(previousPersistenceFingerprint) ||
+                snapshot.PersistenceRevision < 0 ||
+                string.IsNullOrWhiteSpace(snapshot.PersistenceFingerprint))
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.PersistenceConflict,
+                    "The V2 persistence baseline or recovered store metadata is unavailable.");
+            }
+
+            WorkloadTemplate expectedTarget = decisionKind == WorkloadDecisionKind.Update
+                ? session.TargetTemplate
+                : BuildForkTarget(session, safeTargetStableId, forkLabel);
+            if (expectedTarget == null || expectedTarget.Definition == null)
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.InvalidState,
+                    "The V2 persistence recovery target could not be reconstructed safely.");
+            }
+
+            string persistedTargetIdentity =
+                WorkloadSession.GetSourceIdentity(snapshot.TargetTemplate);
+            if (!StringComparer.Ordinal.Equals(
+                    snapshot.TargetTemplate.StableId,
+                    safeTargetStableId) ||
+                !StringComparer.Ordinal.Equals(
+                    persistedTargetIdentity,
+                    WorkloadSession.GetSourceIdentity(expectedTarget)))
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.PersistenceConflict,
+                    "The recovered V2 target identity is stale relative to the active preview.");
+            }
+
+            bool requiresPostWriteRevision = decisionKind == WorkloadDecisionKind.Fork ||
+                !StringComparer.Ordinal.Equals(
+                    persistedTargetIdentity,
+                    sourceIdentity);
+            int expectedRevision = previousPersistenceRevision;
+            if (requiresPostWriteRevision)
+            {
+                if (expectedRevision == int.MaxValue)
+                {
+                    return Fail(
+                        WorkloadDiagnosticCode.PersistenceConflict,
+                        "The V2 persistence revision cannot prove the recovered write.");
+                }
+
+                expectedRevision++;
+            }
+
+            if (snapshot.PersistenceRevision != expectedRevision)
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.PersistenceConflict,
+                    "The recovered V2 persistence revision is not the authoritative post-write revision.");
+            }
+
+            if (decisionKind == WorkloadDecisionKind.Fork &&
+                !StringComparer.Ordinal.Equals(
+                    snapshot.CurrentWorkloadId,
+                    safeTargetStableId))
+            {
+                return Fail(
+                    WorkloadDiagnosticCode.PersistenceConflict,
+                    "The recovered V2 Fork target is not the current workload.");
+            }
+
+            return WorkloadOperationResult<WorkloadPersistenceReceipt>.Ok(
+                new WorkloadPersistenceReceipt(
+                    decisionKind,
+                    sourceStableId,
+                    safeTargetStableId,
+                    sourceIdentity,
+                    persistedTargetIdentity,
+                    snapshot.TargetTemplate,
+                    previousPersistenceRevision,
+                    previousPersistenceFingerprint,
+                    snapshot.PersistenceRevision,
+                    snapshot.PersistenceFingerprint,
+                    snapshot.CurrentWorkloadId));
+        }
+
+        private static WorkloadTemplate BuildForkTarget(
+            WorkloadSession session,
+            string targetStableId,
+            string forkLabel)
+        {
+            WorkloadSessionDecision decision = session.Fork(targetStableId, forkLabel);
+            return decision != null && decision.Accepted
+                ? decision.ResultTemplate
+                : null;
+        }
+
+        private static WorkloadOperationResult<WorkloadPersistenceReceipt> Fail(
+            WorkloadDiagnosticCode code,
+            string message)
+        {
+            return WorkloadOperationResult<WorkloadPersistenceReceipt>.Fail(code, message);
+        }
+    }
+}

--- a/Source/Features/Workloads/V2/WorkloadInspectionSemantics.cs
+++ b/Source/Features/Workloads/V2/WorkloadInspectionSemantics.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+
+namespace Better_Work_Tab.Features.Workloads.V2
+{
+    [Flags]
+    internal enum WorkloadInspectionCellKind
+    {
+        None = 0,
+        ParentPriority = 1,
+        SpecificPriority = 2,
+        Schedule = 4,
+        Ordering = 8
+    }
+
+    /// <summary>
+    /// Stable semantic-to-layout lookup for inspection rendering. The layout
+    /// owns the column indices; this type only indexes canonical defName keys
+    /// and deliberately preserves duplicate projected columns.
+    /// </summary>
+    internal sealed class WorkloadInspectionColumnIndex
+    {
+        private static readonly IReadOnlyList<int> EmptyColumns = new int[0];
+        private readonly Dictionary<string, List<int>> _parentColumns =
+            new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        private readonly Dictionary<WorkloadInspectionSpecificColumnKey, List<int>> _specificColumns =
+            new Dictionary<WorkloadInspectionSpecificColumnKey, List<int>>();
+        private readonly Dictionary<string, List<int>> _orderingColumns =
+            new Dictionary<string, List<int>>(StringComparer.Ordinal);
+
+        public void Clear()
+        {
+            _parentColumns.Clear();
+            _specificColumns.Clear();
+            _orderingColumns.Clear();
+        }
+
+        public void Add(
+            int columnIndex,
+            string workTypeDefName,
+            string workGiverDefName,
+            bool isPriorityCell)
+        {
+            if (!isPriorityCell || string.IsNullOrEmpty(workTypeDefName))
+            {
+                return;
+            }
+
+            AddValue(_orderingColumns, workTypeDefName, columnIndex);
+            if (string.IsNullOrEmpty(workGiverDefName))
+            {
+                AddValue(_parentColumns, workTypeDefName, columnIndex);
+            }
+            else
+            {
+                AddValue(
+                    _specificColumns,
+                    new WorkloadInspectionSpecificColumnKey(
+                        workTypeDefName,
+                        workGiverDefName),
+                    columnIndex);
+            }
+        }
+
+        public IReadOnlyList<int> GetParentColumns(string workTypeDefName)
+        {
+            return GetValues(_parentColumns, workTypeDefName);
+        }
+
+        public IReadOnlyList<int> GetSpecificColumns(
+            string workTypeDefName,
+            string workGiverDefName)
+        {
+            if (string.IsNullOrEmpty(workTypeDefName) ||
+                string.IsNullOrEmpty(workGiverDefName))
+            {
+                return EmptyColumns;
+            }
+
+            return GetValues(
+                _specificColumns,
+                new WorkloadInspectionSpecificColumnKey(
+                    workTypeDefName,
+                    workGiverDefName));
+        }
+
+        public IReadOnlyList<int> GetOrderingColumns(string workTypeDefName)
+        {
+            return GetValues(_orderingColumns, workTypeDefName);
+        }
+
+        private static IReadOnlyList<int> GetValues(
+            Dictionary<string, List<int>> values,
+            string key)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return EmptyColumns;
+            }
+
+            List<int> result;
+            return values.TryGetValue(key, out result) ? result : EmptyColumns;
+        }
+
+        private static void AddValue(
+            Dictionary<string, List<int>> values,
+            string key,
+            int columnIndex)
+        {
+            List<int> indices;
+            if (!values.TryGetValue(key, out indices))
+            {
+                indices = new List<int>(1);
+                values.Add(key, indices);
+            }
+
+            indices.Add(columnIndex);
+        }
+
+        private static IReadOnlyList<int> GetValues(
+            Dictionary<WorkloadInspectionSpecificColumnKey, List<int>> values,
+            WorkloadInspectionSpecificColumnKey key)
+        {
+            List<int> result;
+            return values.TryGetValue(key, out result) ? result : EmptyColumns;
+        }
+
+        private static void AddValue(
+            Dictionary<WorkloadInspectionSpecificColumnKey, List<int>> values,
+            WorkloadInspectionSpecificColumnKey key,
+            int columnIndex)
+        {
+            List<int> indices;
+            if (!values.TryGetValue(key, out indices))
+            {
+                indices = new List<int>(1);
+                values.Add(key, indices);
+            }
+
+            indices.Add(columnIndex);
+        }
+    }
+
+    internal struct WorkloadInspectionSpecificColumnKey :
+        IEquatable<WorkloadInspectionSpecificColumnKey>
+    {
+        internal WorkloadInspectionSpecificColumnKey(
+            string workTypeDefName,
+            string workGiverDefName)
+        {
+            WorkTypeDefName = workTypeDefName ?? string.Empty;
+            WorkGiverDefName = workGiverDefName ?? string.Empty;
+        }
+
+        private string WorkTypeDefName { get; }
+        private string WorkGiverDefName { get; }
+
+        public bool Equals(WorkloadInspectionSpecificColumnKey other)
+        {
+            return StringComparer.Ordinal.Equals(
+                    WorkTypeDefName,
+                    other.WorkTypeDefName) &&
+                StringComparer.Ordinal.Equals(
+                    WorkGiverDefName,
+                    other.WorkGiverDefName);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is WorkloadInspectionSpecificColumnKey &&
+                Equals((WorkloadInspectionSpecificColumnKey)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (StringComparer.Ordinal.GetHashCode(WorkTypeDefName) * 397) ^
+                    StringComparer.Ordinal.GetHashCode(WorkGiverDefName);
+            }
+        }
+    }
+
+    internal struct WorkloadInspectionCellKey : IEquatable<WorkloadInspectionCellKey>
+    {
+        public WorkloadInspectionCellKey(int rowIndex, int columnIndex)
+        {
+            RowIndex = rowIndex;
+            ColumnIndex = columnIndex;
+        }
+
+        public int RowIndex { get; private set; }
+        public int ColumnIndex { get; private set; }
+
+        public bool Equals(WorkloadInspectionCellKey other)
+        {
+            return RowIndex == other.RowIndex && ColumnIndex == other.ColumnIndex;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is WorkloadInspectionCellKey &&
+                Equals((WorkloadInspectionCellKey)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (RowIndex * 397) ^ ColumnIndex;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Aggregates semantic flags before drawing. Multiple semantic changes may
+    /// intentionally address the same visible cell and must be composed once.
+    /// </summary>
+    internal sealed class WorkloadInspectionCellMasks
+    {
+        private readonly Dictionary<WorkloadInspectionCellKey, WorkloadInspectionCellKind> _values =
+            new Dictionary<WorkloadInspectionCellKey, WorkloadInspectionCellKind>();
+
+        public int Count => _values.Count;
+        internal Dictionary<WorkloadInspectionCellKey, WorkloadInspectionCellKind> Entries =>
+            _values;
+
+        public void Clear()
+        {
+            _values.Clear();
+        }
+
+        public void Add(int rowIndex, int columnIndex, WorkloadInspectionCellKind kind)
+        {
+            if (kind == WorkloadInspectionCellKind.None)
+            {
+                return;
+            }
+
+            WorkloadInspectionCellKey key =
+                new WorkloadInspectionCellKey(rowIndex, columnIndex);
+            WorkloadInspectionCellKind existing;
+            _values.TryGetValue(key, out existing);
+            _values[key] = existing | kind;
+        }
+
+        public bool TryGet(
+            int rowIndex,
+            int columnIndex,
+            out WorkloadInspectionCellKind kind)
+        {
+            return _values.TryGetValue(
+                new WorkloadInspectionCellKey(rowIndex, columnIndex),
+                out kind);
+        }
+    }
+
+    internal static class WorkloadInspectionSemantics
+    {
+        /// <summary>
+        /// Manual mode is globally effective even though the compatibility
+        /// storage contains one entry per represented pawn/work type. Missing
+        /// keys caused only by membership churn do not constitute a global
+        /// mode change.
+        /// </summary>
+        public static bool HasEffectiveManualModeChange(
+            WorkloadProjectedState before,
+            WorkloadProjectedState after)
+        {
+            bool beforeMode;
+            bool afterMode;
+            if (!TryGetEffectiveManualMode(before, out beforeMode) ||
+                !TryGetEffectiveManualMode(after, out afterMode))
+            {
+                return false;
+            }
+
+            return beforeMode != afterMode;
+        }
+
+        private static bool TryGetEffectiveManualMode(
+            WorkloadProjectedState state,
+            out bool mode)
+        {
+            mode = false;
+            if (state == null || state.ManualModes == null ||
+                state.ManualModes.Count == 0)
+            {
+                return false;
+            }
+
+            bool first = state.ManualModes[0]?.Manual ?? false;
+            for (int i = 1; i < state.ManualModes.Count; i++)
+            {
+                WorkloadManualModeEntry entry = state.ManualModes[i];
+                if (entry != null && entry.Manual != first)
+                {
+                    return false;
+                }
+            }
+
+            mode = first;
+            return true;
+        }
+    }
+}

--- a/Source/UI/Chrome/WorkTabChrome.cs
+++ b/Source/UI/Chrome/WorkTabChrome.cs
@@ -16,6 +16,7 @@ using Better_Work_Tab.UI.RuleBuilder;
 using Better_Work_Tab.UI.Settings;
 using Better_Work_Tab.UI.WorkGiverReassignments;
 using Better_Work_Tab.UI.WorkGrid.Projection;
+using Better_Work_Tab.UI.Workloads;
 using RimWorld;
 using Spine.Profiling;
 using Spine.UI.WidgetExtensions;
@@ -238,7 +239,7 @@ namespace Better_Work_Tab.UI.Chrome
             Text.Font = GameFont.Small;
             GUI.color = Color.white;
             Text.Anchor = TextAnchor.UpperLeft;
-            Rect rect = new Rect(5f, 5f, 140f, 30f);
+            Rect rect = WorkTabChromeGeometry.GetManualPrioritiesCheckboxRect();
             int maxPriority = WorkPrioritySystem.GetMaxPriority();
             EnsureUiTextCache(maxPriority);
             bool wasEnabled = WorkTabEffectiveStateRuntime.IsPreviewActive
@@ -255,6 +256,8 @@ namespace Better_Work_Tab.UI.Chrome
                 requestedEnabled = wasEnabled;
             }
 
+            DrawManualModeInspectionIndicator(rect);
+
             bool isEnabled = WorkTabEffectiveStateRuntime.IsPreviewActive
                 ? requestedEnabled
                 : Current.Game.playSettings.useWorkPriorities;
@@ -270,6 +273,24 @@ namespace Better_Work_Tab.UI.Chrome
             {
                 UIHighlighter.HighlightOpportunity(rect, "ManualPriorities-Off");
             }
+        }
+
+        private static void DrawManualModeInspectionIndicator(Rect checkboxRect)
+        {
+            WorkloadPreviewController preview = WorkloadPreviewController.Current;
+            if (preview == null ||
+                !WorkloadPreviewController.IsInspectionActiveForCurrentTab ||
+                !preview.HasManualModeInspectionChange)
+            {
+                return;
+            }
+
+            GUI.color = new Color(0.95f, 0.70f, 0.25f, 0.9f);
+            Widgets.DrawBox(checkboxRect.ExpandedBy(2f), 2);
+            GUI.color = Color.white;
+            TooltipHandler.TipRegion(
+                checkboxRect,
+                "This preview changes the global manual-priority mode.");
         }
 
         private void DrawPriorityLegend(Rect rect)

--- a/Source/UI/Chrome/WorkTabChromeGeometry.cs
+++ b/Source/UI/Chrome/WorkTabChromeGeometry.cs
@@ -24,6 +24,16 @@ namespace Better_Work_Tab.UI.Chrome
         private const float InfoIconSize = 24f;
         private const float ContextSettingsHintWidth = 230f;
 
+        internal static Rect GetManualPrioritiesCheckboxRect()
+        {
+            return new Rect(5f, 5f, 140f, 30f);
+        }
+
+        internal static Rect GetManualPrioritiesContextRect()
+        {
+            return new Rect(5f, 5f, 220f, 90f);
+        }
+
         internal static Rect GetInfoIconRect(Rect inRect)
         {
             return new Rect(

--- a/Source/UI/Settings/BWTWorkTabContextSettingsRouter.cs
+++ b/Source/UI/Settings/BWTWorkTabContextSettingsRouter.cs
@@ -736,7 +736,7 @@ namespace Better_Work_Tab.UI.Settings
 
         private static bool TryGetManualPrioritiesContext(Vector2 mousePosition)
         {
-            return new Rect(5f, 5f, 220f, 90f).Contains(mousePosition);
+            return WorkTabChromeGeometry.GetManualPrioritiesContextRect().Contains(mousePosition);
         }
 
         private static bool TryGetPriorityLegendContext(Rect inRect, Vector2 mousePosition)

--- a/Source/UI/WorkGrid/Rendering/WorkTabBodyRenderer.cs
+++ b/Source/UI/WorkGrid/Rendering/WorkTabBodyRenderer.cs
@@ -46,10 +46,17 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
         private readonly List<WorkTabLayoutColumn> _visibleRenderColumns = new List<WorkTabLayoutColumn>(64);
         private readonly List<InspectionColumnBinding> _inspectionColumnBindings =
             new List<InspectionColumnBinding>(64);
+        private readonly WorkloadInspectionColumnIndex _inspectionColumnIndex =
+            new WorkloadInspectionColumnIndex();
         private readonly Dictionary<int, int> _inspectionVisibleRows =
             new Dictionary<int, int>();
-        private readonly HashSet<InspectionDrawKey> _inspectionDrawnCells =
-            new HashSet<InspectionDrawKey>();
+        private readonly List<int> _inspectionVisiblePawnRows = new List<int>(32);
+        private readonly Dictionary<int, float> _inspectionVisibleRowOffsets =
+            new Dictionary<int, float>();
+        private readonly Dictionary<int, WorkloadInspectionCellKind> _inspectionGlobalColumns =
+            new Dictionary<int, WorkloadInspectionCellKind>();
+        private readonly WorkloadInspectionCellMasks _inspectionCellMasks =
+            new WorkloadInspectionCellMasks();
         private IReadOnlyList<WorkTabLayoutColumn> _inspectionBindingColumns;
         private int _inspectionBindingLayoutRevision = int.MinValue;
         private int _inspectionBindingSubWorkRevision = int.MinValue;
@@ -73,36 +80,6 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             internal WorkGiverDef WorkGiver { get; }
             internal bool IsExpandBesideChild { get; }
             internal bool IsPriorityCell { get; }
-        }
-
-        private readonly struct InspectionDrawKey : IEquatable<InspectionDrawKey>
-        {
-            internal InspectionDrawKey(int rowIndex, int columnIndex)
-            {
-                RowIndex = rowIndex;
-                ColumnIndex = columnIndex;
-            }
-
-            private int RowIndex { get; }
-            private int ColumnIndex { get; }
-
-            public bool Equals(InspectionDrawKey other)
-            {
-                return RowIndex == other.RowIndex && ColumnIndex == other.ColumnIndex;
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is InspectionDrawKey && Equals((InspectionDrawKey)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (RowIndex * 397) ^ ColumnIndex;
-                }
-            }
         }
 
         internal WorkTabBodyRenderer(WorkTabViewportController viewportController)
@@ -245,7 +222,9 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
                         totalWidth,
                         rowGeometry,
                         visibleRows,
-                        layout.LayoutRevision));
+                        layout.LayoutRevision,
+                        table.scrollPosition.x,
+                        viewport.OutRect.width));
                 }
                 else
                 {
@@ -292,7 +271,9 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
                         totalWidth,
                         rowGeometry,
                         visibleRows,
-                        layout.LayoutRevision);
+                        layout.LayoutRevision,
+                        table.scrollPosition.x,
+                        viewport.OutRect.width);
                 }
             }
             finally
@@ -689,7 +670,9 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             float totalWidth,
             WorkGridGeometrySnapshot rowGeometry,
             WorkGridIndexRange visibleRows,
-            int layoutRevision)
+            int layoutRevision,
+            float horizontalScrollX,
+            float horizontalViewportWidth)
         {
             if (!WorkloadPreviewController.IsInspectionActiveForCurrentTab)
             {
@@ -733,55 +716,13 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             }
 
             _inspectionVisibleRows.Clear();
-            _inspectionDrawnCells.Clear();
-            for (int rowIndex = visibleRows.Start; rowIndex < visibleRows.EndExclusive; rowIndex++)
-            {
-                Pawn pawn = rowDescriptors[rowIndex]?.Pawn;
-                if (pawn != null && pawn.thingIDNumber > 0)
-                {
-                    _inspectionVisibleRows[pawn.thingIDNumber] = rowIndex;
-                }
-            }
-
-            for (int targetIndex = 0; targetIndex < targets.Count; targetIndex++)
-            {
-                WorkloadInspectionTarget target = targets[targetIndex];
-                if (target.Scope == WorkloadTargetScope.GlobalShared)
-                {
-                    DrawGlobalInspectionTarget(
-                        target,
-                        rowDescriptors,
-                        columns,
-                        totalWidth,
-                        rowGeometry,
-                        visibleRows,
-                        preview);
-                }
-                else if (_inspectionVisibleRows.TryGetValue(target.PawnId, out int rowIndex))
-                {
-                    DrawLocalInspectionTarget(
-                        target,
-                        rowIndex,
-                        rowDescriptors,
-                        columns,
-                        totalWidth,
-                        rowGeometry,
-                        visibleRows,
-                        preview);
-                }
-            }
-        }
-
-        private void DrawGlobalInspectionTarget(
-            WorkloadInspectionTarget target,
-            List<RowDescriptor> rowDescriptors,
-            IReadOnlyList<WorkTabLayoutColumn> columns,
-            float totalWidth,
-            WorkGridGeometrySnapshot rowGeometry,
-            WorkGridIndexRange visibleRows,
-            WorkloadPreviewController preview)
-        {
-            float currentY = 0f;
+            _inspectionVisiblePawnRows.Clear();
+            _inspectionVisibleRowOffsets.Clear();
+            _inspectionGlobalColumns.Clear();
+            _inspectionCellMasks.Clear();
+            float currentY = rowGeometry != null && visibleRows.Start < rowGeometry.Rows.Count
+                ? rowGeometry.Rows[visibleRows.Start].OffsetY
+                : 0f;
             for (int rowIndex = visibleRows.Start; rowIndex < visibleRows.EndExclusive; rowIndex++)
             {
                 if (rowGeometry != null)
@@ -789,142 +730,196 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
                     currentY = rowGeometry.Rows[rowIndex].OffsetY;
                 }
 
-                RowDescriptor descriptor = rowDescriptors[rowIndex];
-                if (descriptor?.Pawn != null)
+                _inspectionVisibleRowOffsets[rowIndex] = currentY;
+                Pawn pawn = rowDescriptors[rowIndex]?.Pawn;
+                if (pawn != null && pawn.thingIDNumber > 0)
                 {
-                    DrawInspectionTargetOnRow(
-                        target,
-                        rowIndex,
-                        currentY,
-                        descriptor,
-                        columns,
-                        totalWidth,
-                        preview);
+                    _inspectionVisibleRows[pawn.thingIDNumber] = rowIndex;
+                    _inspectionVisiblePawnRows.Add(rowIndex);
                 }
-
                 if (rowGeometry == null)
                 {
-                    currentY += descriptor?.Height ?? 0f;
+                    currentY += rowDescriptors[rowIndex]?.Height ?? 0f;
                 }
             }
-        }
 
-        private void DrawLocalInspectionTarget(
-            WorkloadInspectionTarget target,
-            int rowIndex,
-            List<RowDescriptor> rowDescriptors,
-            IReadOnlyList<WorkTabLayoutColumn> columns,
-            float totalWidth,
-            WorkGridGeometrySnapshot rowGeometry,
-            WorkGridIndexRange visibleRows,
-            WorkloadPreviewController preview)
-        {
-            RowDescriptor descriptor = rowDescriptors[rowIndex];
-            if (descriptor?.Pawn == null ||
-                rowIndex < visibleRows.Start || rowIndex >= visibleRows.EndExclusive)
+            for (int targetIndex = 0; targetIndex < targets.Count; targetIndex++)
             {
-                return;
-            }
-
-            float currentY = rowGeometry != null
-                ? rowGeometry.Rows[rowIndex].OffsetY
-                : GetRowOffset(rowDescriptors, visibleRows.Start, rowIndex);
-            DrawInspectionTargetOnRow(
-                target,
-                rowIndex,
-                currentY,
-                descriptor,
-                columns,
-                totalWidth,
-                preview);
-        }
-
-        private void DrawInspectionTargetOnRow(
-            WorkloadInspectionTarget target,
-            int rowIndex,
-            float currentY,
-            RowDescriptor descriptor,
-            IReadOnlyList<WorkTabLayoutColumn> columns,
-            float totalWidth,
-            WorkloadPreviewController preview)
-        {
-            Rect rowRect = new Rect(0f, currentY, totalWidth, descriptor.Height);
-            for (int columnIndex = 0; columnIndex < _inspectionColumnBindings.Count; columnIndex++)
-            {
-                InspectionColumnBinding binding = _inspectionColumnBindings[columnIndex];
-                if (!binding.IsPriorityCell || !MatchesInspectionTarget(target, binding))
+                WorkloadInspectionTarget target = targets[targetIndex];
+                IReadOnlyList<int> matchingColumns = GetInspectionColumns(target);
+                WorkloadInspectionCellKind kind = GetInspectionCellKind(target.Kind);
+                if (matchingColumns.Count == 0 || kind == WorkloadInspectionCellKind.None)
                 {
                     continue;
                 }
 
-                InspectionDrawKey drawKey = new InspectionDrawKey(rowIndex, columnIndex);
-                if (!_inspectionDrawnCells.Add(drawKey))
+                if (target.Scope == WorkloadTargetScope.GlobalShared)
+                {
+                    for (int columnIndex = 0; columnIndex < matchingColumns.Count; columnIndex++)
+                    {
+                        int index = matchingColumns[columnIndex];
+                        if (index < 0 || index >= columns.Count ||
+                            !IsInspectionColumnVisible(
+                                columns[index],
+                                horizontalScrollX,
+                                horizontalViewportWidth))
+                        {
+                            continue;
+                        }
+
+                        WorkloadInspectionCellKind existing;
+                        _inspectionGlobalColumns.TryGetValue(index, out existing);
+                        _inspectionGlobalColumns[index] = existing | kind;
+                    }
+                }
+                else if (_inspectionVisibleRows.TryGetValue(target.PawnId, out int rowIndex))
+                {
+                    AddInspectionColumnsForRow(
+                        rowIndex,
+                        matchingColumns,
+                        kind,
+                        columns,
+                        horizontalScrollX,
+                        horizontalViewportWidth);
+                }
+            }
+
+            foreach (KeyValuePair<int, WorkloadInspectionCellKind> globalColumn in _inspectionGlobalColumns)
+            {
+                for (int rowIndex = 0; rowIndex < _inspectionVisiblePawnRows.Count; rowIndex++)
+                {
+                    _inspectionCellMasks.Add(
+                        _inspectionVisiblePawnRows[rowIndex],
+                        globalColumn.Key,
+                        globalColumn.Value);
+                }
+            }
+
+            foreach (KeyValuePair<WorkloadInspectionCellKey, WorkloadInspectionCellKind> cell in
+                     _inspectionCellMasks.Entries)
+            {
+                int rowIndex = cell.Key.RowIndex;
+                int columnIndex = cell.Key.ColumnIndex;
+                if (!_inspectionVisibleRowOffsets.TryGetValue(rowIndex, out float rowY) ||
+                    rowIndex < visibleRows.Start || rowIndex >= visibleRows.EndExclusive ||
+                    rowIndex >= rowDescriptors.Count || columnIndex < 0 ||
+                    columnIndex >= columns.Count)
                 {
                     continue;
                 }
 
-                WorkloadInspectionCellKind kind = preview.GetInspectionCellKind(
-                    descriptor.Pawn,
-                    binding.WorkType,
-                    binding.WorkGiver);
-                if (kind == WorkloadInspectionCellKind.None)
+                RowDescriptor descriptor = rowDescriptors[rowIndex];
+                if (descriptor?.Pawn == null)
                 {
                     continue;
                 }
 
                 Rect cellRect = WorkGridInteractionGeometry.GetAnimatedBodyContentRect(
                     columns[columnIndex],
-                    rowRect);
-                DrawInspectionCell(cellRect, binding.IsExpandBesideChild, kind);
+                    new Rect(0f, rowY, totalWidth, descriptor.Height));
+                DrawInspectionCell(
+                    cellRect,
+                    _inspectionColumnBindings[columnIndex].IsExpandBesideChild,
+                    cell.Value);
             }
         }
 
-        private static bool MatchesInspectionTarget(
-            WorkloadInspectionTarget target,
-            InspectionColumnBinding binding)
+        private void AddInspectionColumnsForRow(
+            int rowIndex,
+            IReadOnlyList<int> matchingColumns,
+            WorkloadInspectionCellKind kind,
+            IReadOnlyList<WorkTabLayoutColumn> columns,
+            float horizontalScrollX,
+            float horizontalViewportWidth)
         {
-            if (binding.WorkType == null ||
-                !StringComparer.Ordinal.Equals(binding.WorkType.defName, target.WorkType))
+            for (int columnIndex = 0; columnIndex < matchingColumns.Count; columnIndex++)
             {
-                return false;
+                AddInspectionCell(
+                    rowIndex,
+                    matchingColumns[columnIndex],
+                    kind,
+                    columns,
+                    horizontalScrollX,
+                    horizontalViewportWidth);
+            }
+        }
+
+        private void AddInspectionCell(
+            int rowIndex,
+            int columnIndex,
+            WorkloadInspectionCellKind kind,
+            IReadOnlyList<WorkTabLayoutColumn> columns,
+            float horizontalScrollX,
+            float horizontalViewportWidth)
+        {
+            if (columnIndex < 0 || columnIndex >= _inspectionColumnBindings.Count ||
+                columnIndex >= columns.Count ||
+                !IsInspectionColumnVisible(
+                    columns[columnIndex],
+                    horizontalScrollX,
+                    horizontalViewportWidth))
+            {
+                return;
             }
 
-            bool hasWorkGiver = binding.WorkGiver != null;
-            bool targetHasWorkGiver = !string.IsNullOrEmpty(target.WorkGiver);
+            _inspectionCellMasks.Add(rowIndex, columnIndex, kind);
+        }
+
+        private IReadOnlyList<int> GetInspectionColumns(WorkloadInspectionTarget target)
+        {
             switch (target.Kind)
             {
                 case WorkloadInspectionTargetKind.ParentPriority:
-                    return !hasWorkGiver && !targetHasWorkGiver;
+                    return _inspectionColumnIndex.GetParentColumns(target.WorkType);
                 case WorkloadInspectionTargetKind.SpecificPriority:
-                    return hasWorkGiver && targetHasWorkGiver &&
-                        StringComparer.Ordinal.Equals(binding.WorkGiver.defName, target.WorkGiver);
+                    return _inspectionColumnIndex.GetSpecificColumns(target.WorkType, target.WorkGiver);
                 case WorkloadInspectionTargetKind.Schedule:
                     if (target.ScheduleKind == (int)WorkloadScheduleTargetKind.ParentWorkType)
                     {
-                        return !hasWorkGiver;
+                        return _inspectionColumnIndex.GetParentColumns(target.WorkType);
                     }
-
-                    return hasWorkGiver && targetHasWorkGiver &&
-                        StringComparer.Ordinal.Equals(binding.WorkGiver.defName, target.WorkGiver);
+                    return _inspectionColumnIndex.GetSpecificColumns(target.WorkType, target.WorkGiver);
                 case WorkloadInspectionTargetKind.Ordering:
-                    return true;
+                    return _inspectionColumnIndex.GetOrderingColumns(target.WorkType);
                 default:
-                    return false;
+                    return new int[0];
             }
         }
 
-        private static float GetRowOffset(
-            List<RowDescriptor> rowDescriptors,
-            int startRow,
-            int targetRow)
+        private static WorkloadInspectionCellKind GetInspectionCellKind(
+            WorkloadInspectionTargetKind kind)
         {
-            float offset = 0f;
-            for (int rowIndex = startRow; rowIndex < targetRow; rowIndex++)
+            switch (kind)
             {
-                offset += rowDescriptors[rowIndex]?.Height ?? 0f;
+                case WorkloadInspectionTargetKind.ParentPriority:
+                    return WorkloadInspectionCellKind.ParentPriority;
+                case WorkloadInspectionTargetKind.SpecificPriority:
+                    return WorkloadInspectionCellKind.SpecificPriority;
+                case WorkloadInspectionTargetKind.Schedule:
+                    return WorkloadInspectionCellKind.Schedule;
+                case WorkloadInspectionTargetKind.Ordering:
+                    return WorkloadInspectionCellKind.Ordering;
+                default:
+                    return WorkloadInspectionCellKind.None;
+            }
+        }
+
+        private static bool IsInspectionColumnVisible(
+            WorkTabLayoutColumn column,
+            float horizontalScrollX,
+            float horizontalViewportWidth)
+        {
+            if (horizontalViewportWidth <= 0f)
+            {
+                return true;
             }
 
-            return offset;
+            WorkGridAnimatedColumnGeometry geometry =
+                WorkGridInteractionGeometry.GetAnimatedColumn(column);
+            float visibleLeft = horizontalScrollX - HorizontalCullBuffer;
+            float visibleRight = horizontalScrollX + horizontalViewportWidth + HorizontalCullBuffer;
+            return geometry.BodyContentX + geometry.Width >= visibleLeft &&
+                geometry.BodyContentX <= visibleRight;
         }
 
         private static void DrawWorkloadInspectionRows(
@@ -971,6 +966,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             }
 
             _inspectionColumnBindings.Clear();
+            _inspectionColumnIndex.Clear();
             if (columns == null)
             {
                 _inspectionBindingColumns = columns;
@@ -999,11 +995,17 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
                     }
                 }
 
+                bool isPriorityCell = column.Column?.Worker is PawnColumnWorker_WorkPriority;
                 _inspectionColumnBindings.Add(new InspectionColumnBinding(
                     workType,
                     workGiver,
                     column.IsExpandBesideChild,
-                    column.Column?.Worker is PawnColumnWorker_WorkPriority));
+                    isPriorityCell));
+                _inspectionColumnIndex.Add(
+                    i,
+                    workType?.defName,
+                    workGiver?.defName,
+                    isPriorityCell);
             }
 
             _inspectionBindingColumns = columns;
@@ -1016,35 +1018,45 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             bool isExpandBesideChild,
             WorkloadInspectionCellKind kind)
         {
-            switch (kind)
+            Rect priorityRect = WorkPriorityCellGeometry.GetDrawnPriorityBoxRect(
+                cellRect,
+                isExpandBesideChild);
+            if ((kind & WorkloadInspectionCellKind.ParentPriority) != 0)
             {
-                case WorkloadInspectionCellKind.ParentPriority:
+                HighlightDrawer.DrawHighlight(
+                    priorityRect,
+                    new Color(0.30f, 0.75f, 0.68f, 0.32f));
+            }
+            if ((kind & WorkloadInspectionCellKind.SpecificPriority) != 0)
+            {
+                Rect specificRect = priorityRect.ContractedBy(2f);
+                if (specificRect.width > 0f && specificRect.height > 0f)
+                {
                     HighlightDrawer.DrawHighlight(
-                        WorkPriorityCellGeometry.GetDrawnPriorityBoxRect(
-                            cellRect,
-                            isExpandBesideChild),
-                        new Color(0.30f, 0.75f, 0.68f, 0.32f));
-                    break;
-                case WorkloadInspectionCellKind.SpecificPriority:
-                    HighlightDrawer.DrawHighlight(
-                        WorkPriorityCellGeometry.GetDrawnPriorityBoxRect(
-                            cellRect,
-                            isExpandBesideChild),
+                        specificRect,
                         new Color(0.45f, 0.58f, 0.92f, 0.34f));
-                    break;
-                case WorkloadInspectionCellKind.Schedule:
-                    DrawInspectionStripe(cellRect, new Color(0.95f, 0.70f, 0.25f, 0.88f));
-                    break;
-                case WorkloadInspectionCellKind.Ordering:
-                    DrawInspectionStripe(cellRect, new Color(0.72f, 0.46f, 0.90f, 0.88f));
-                    break;
+                }
+            }
+            if ((kind & WorkloadInspectionCellKind.Schedule) != 0)
+            {
+                DrawInspectionStripe(
+                    cellRect,
+                    new Color(0.95f, 0.70f, 0.25f, 0.88f),
+                    right: false);
+            }
+            if ((kind & WorkloadInspectionCellKind.Ordering) != 0)
+            {
+                DrawInspectionStripe(
+                    cellRect,
+                    new Color(0.72f, 0.46f, 0.90f, 0.88f),
+                    right: true);
             }
         }
 
-        private static void DrawInspectionStripe(Rect cellRect, Color color)
+        private static void DrawInspectionStripe(Rect cellRect, Color color, bool right)
         {
             Rect stripe = new Rect(
-                cellRect.xMin + 1f,
+                right ? cellRect.xMax - 4f : cellRect.xMin + 1f,
                 cellRect.yMin + 1f,
                 Mathf.Min(3f, Mathf.Max(0f, cellRect.width - 2f)),
                 Mathf.Max(0f, cellRect.height - 2f));

--- a/Source/UI/Workloads/WorkloadGateway.cs
+++ b/Source/UI/Workloads/WorkloadGateway.cs
@@ -737,7 +737,8 @@ namespace Better_Work_Tab.UI.Workloads
         internal static WorkloadOperationResult<WorkloadSession> RebaseV2PreviewAfterPersistence(
             WorkloadPersistenceReceipt receipt,
             WorkloadDecisionKind decisionKind = WorkloadDecisionKind.Apply,
-            string targetStableId = null)
+            string targetStableId = null,
+            string forkLabel = null)
         {
             if (!TryBind(out LegacyWorkloadBackend unusedLegacy, out Workload2Backend modern))
             {
@@ -760,7 +761,10 @@ namespace Better_Work_Tab.UI.Workloads
             if (receipt == null)
             {
                 WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
-                    modern.RecoverPersistenceReceipt(decisionKind, targetStableId);
+                    modern.RecoverPersistenceReceipt(
+                        decisionKind,
+                        targetStableId,
+                        forkLabel);
                 if (!recovered.Succeeded || recovered.Value == null)
                 {
                     return WorkloadOperationResult<WorkloadSession>.Fail(
@@ -974,15 +978,6 @@ namespace Better_Work_Tab.UI.Workloads
     /// remains the only persistence/live-commit crossing point; this controller
     /// only keeps the session-local model and its effective-state providers.
     /// </summary>
-    internal enum WorkloadInspectionCellKind
-    {
-        None = 0,
-        ParentPriority = 1,
-        SpecificPriority = 2,
-        Schedule = 3,
-        Ordering = 4
-    }
-
     internal enum WorkloadInspectionTargetKind
     {
         ParentPriority = 0,
@@ -1057,6 +1052,7 @@ namespace Better_Work_Tab.UI.Workloads
         private WorkloadInspectionContext _inspectionIndexContext;
         private WorkloadInspectionContext _inspectionContext;
         private bool _hasInspectionCellTargets;
+        private bool _hasManualModeInspectionChange;
         private WorkloadMembershipSnapshot _membershipSnapshot;
         private WorkloadSession _membershipSnapshotSession;
         private long _membershipSnapshotProjectionRevision = long.MinValue;
@@ -1269,6 +1265,20 @@ namespace Better_Work_Tab.UI.Workloads
 
                 EnsureInspectionIndex();
                 return _hasInspectionCellTargets;
+            }
+        }
+
+        internal bool HasManualModeInspectionChange
+        {
+            get
+            {
+                if (!IsInspectionActive)
+                {
+                    return false;
+                }
+
+                EnsureInspectionIndex();
+                return _hasManualModeInspectionChange;
             }
         }
 
@@ -1627,7 +1637,8 @@ namespace Better_Work_Tab.UI.Workloads
                     WorkloadGateway.RebaseV2PreviewAfterPersistence(
                         status?.Result?.PersistenceReceipt,
                         _multiplayerDecision,
-                        expectedStableId);
+                        expectedStableId,
+                        _multiplayerForkLabel);
                 WorkloadOperationResult<WorkloadSession> adopted =
                     rebased.Succeeded
                         ? WorkloadGateway.AdoptV2PreviewSession()
@@ -2720,101 +2731,6 @@ namespace Better_Work_Tab.UI.Workloads
             }
         }
 
-        internal WorkloadInspectionCellKind GetInspectionCellKind(
-            Pawn pawn,
-            WorkTypeDef workType,
-            WorkGiverDef workGiver)
-        {
-            EnsureInspectionIndex();
-            if (pawn == null || pawn.thingIDNumber <= 0 || workType == null ||
-                workType.defName.NullOrEmpty())
-            {
-                return WorkloadInspectionCellKind.None;
-            }
-
-            int pawnId = pawn.thingIDNumber;
-            string workTypeName = workType.defName;
-            string workGiverName = workGiver?.defName;
-            if (_changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.ParentPriority,
-                    WorkloadTargetScope.PawnLocal,
-                    0,
-                    pawnId,
-                    workTypeName,
-                    null)))
-            {
-                return WorkloadInspectionCellKind.ParentPriority;
-            }
-
-            if (_changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.Schedule,
-                    WorkloadTargetScope.PawnLocal,
-                    (int)WorkloadScheduleTargetKind.ParentWorkType,
-                    pawnId,
-                    workTypeName,
-                    null)) ||
-                (workGiverName != null && _changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.Schedule,
-                    WorkloadTargetScope.PawnLocal,
-                    (int)WorkloadScheduleTargetKind.WorkGiver,
-                    pawnId,
-                    workTypeName,
-                    workGiverName))) ||
-                (workGiverName != null && _changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.Schedule,
-                    WorkloadTargetScope.GlobalShared,
-                    (int)WorkloadScheduleTargetKind.WorkGiver,
-                    -1,
-                    workTypeName,
-                    workGiverName))))
-            {
-                return WorkloadInspectionCellKind.Schedule;
-            }
-
-            if (_changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.Ordering,
-                    WorkloadTargetScope.PawnLocal,
-                    0,
-                    pawnId,
-                    workTypeName,
-                    null)) ||
-                _changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.Ordering,
-                    WorkloadTargetScope.GlobalShared,
-                    0,
-                    -1,
-                    workTypeName,
-                    null)))
-            {
-                return WorkloadInspectionCellKind.Ordering;
-            }
-
-            if (workGiverName == null)
-            {
-                return WorkloadInspectionCellKind.None;
-            }
-
-            if (_changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.SpecificPriority,
-                    WorkloadTargetScope.PawnLocal,
-                    0,
-                    pawnId,
-                    workTypeName,
-                    workGiverName)) ||
-                _changedInspectionTargets.Contains(new InspectionTargetKey(
-                    InspectionTargetKind.SpecificPriority,
-                    WorkloadTargetScope.GlobalShared,
-                    0,
-                    -1,
-                    workTypeName,
-                    workGiverName)))
-            {
-                return WorkloadInspectionCellKind.SpecificPriority;
-            }
-
-            return WorkloadInspectionCellKind.None;
-        }
-
         /// <summary>
         /// Applies a typed preview intent from a context-menu callback. These
         /// callbacks run outside the Work-tab provider scope, so they must
@@ -3345,8 +3261,18 @@ namespace Better_Work_Tab.UI.Workloads
             _inspectionTargets.Clear();
             _changedSchedulePawnIds.Clear();
             _hasInspectionCellTargets = false;
+            _hasManualModeInspectionChange = false;
             if (diff != null)
             {
+                WorkloadProjectedState inspectionBaseline =
+                    _inspectionContext == WorkloadInspectionContext.Live
+                        ? _session.LiveBaselineState
+                        : _session.TemplateBaselineState;
+                _hasManualModeInspectionChange =
+                    WorkloadInspectionSemantics.HasEffectiveManualModeChange(
+                        inspectionBaseline,
+                        _session.ProjectedState);
+
                 for (int i = 0; i < diff.Changes.Count; i++)
                 {
                     WorkloadChange change = diff.Changes[i];
@@ -3373,7 +3299,6 @@ namespace Better_Work_Tab.UI.Workloads
                     switch (change.Dimension)
                     {
                         case WorkloadStateDimension.ParentPriorities:
-                        case WorkloadStateDimension.ManualModes:
                             if (pawnId > 0 && workType != null && workType.IsValid)
                             {
                                 _changedInspectionTargets.Add(new InspectionTargetKey(
@@ -3385,6 +3310,11 @@ namespace Better_Work_Tab.UI.Workloads
                                     null));
                                 _hasInspectionCellTargets = true;
                             }
+                            break;
+                        case WorkloadStateDimension.ManualModes:
+                            // Manual mode is globally effective. Its
+                            // compatibility entries are intentionally not
+                            // projected into pawn x WorkType cell targets.
                             break;
                         case WorkloadStateDimension.Schedules:
                             if (pawnId > 0)
@@ -3464,6 +3394,7 @@ namespace Better_Work_Tab.UI.Workloads
             _inspectionTargets.Clear();
             _changedSchedulePawnIds.Clear();
             _hasInspectionCellTargets = false;
+            _hasManualModeInspectionChange = false;
             _inspectionIndexSession = null;
             _inspectionIndexSessionRevision = long.MinValue;
             _inspectionIndexContext = WorkloadInspectionContext.None;

--- a/Tests/WorkloadsV2/BackendTransactionTests.cs
+++ b/Tests/WorkloadsV2/BackendTransactionTests.cs
@@ -441,12 +441,12 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
                 "receipt recovery must round-trip the authoritative persisted target");
             TestAssert.Contains(
                 recovery,
-                "receipt.Value.TargetIdentity",
-                "receipt recovery must validate the current target identity");
+                "WorkloadPersistenceReceiptRecovery.TryRecover(",
+                "receipt recovery must use the pure fail-closed recovery seam");
             TestAssert.Contains(
                 recovery,
-                "receipt.Value.CurrentWorkloadId",
-                "receipt recovery must validate the current workload identity");
+                "new WorkloadPersistenceRecoverySnapshot(",
+                "receipt recovery must pass an authoritative persistence snapshot to the pure seam");
             TestAssert.Contains(
                 backend,
                 "WorkloadScope synchronizedScope",

--- a/Tests/WorkloadsV2/GatewayLifecycleTests.cs
+++ b/Tests/WorkloadsV2/GatewayLifecycleTests.cs
@@ -18,6 +18,14 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
             string header = Read(root, "Source", "UI", "HeaderButtons.cs");
             string gateway = Read(root, "Source", "UI", "Workloads", "WorkloadGateway.cs");
             string renderer = Read(root, "Source", "UI", "WorkGrid", "Rendering", "WorkTabBodyRenderer.cs");
+            string chrome = Read(root, "Source", "UI", "Chrome", "WorkTabChrome.cs");
+            string inspectionSemantics = Read(
+                root,
+                "Source",
+                "Features",
+                "Workloads",
+                "V2",
+                "WorkloadInspectionSemantics.cs");
             string backend = Read(root, "Source", "Features", "Workloads", "V2", "Runtime", "Workload2Backend.cs");
             string session = Read(root, "Source", "Features", "Workloads", "V2", "WorkloadSession.cs");
             string english = Read(root, "Languages", "English", "Keyed", "English.xml");
@@ -29,7 +37,12 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
             NarrowFooterGeometryIsBounded(header);
             DeletedFeedbackCopyIsAbsent(english, settings);
             FooterActionsAcceptTypedState(gateway, session);
-            InspectionUsesRevisionCachesAndContext(header, gateway, renderer);
+            InspectionUsesRevisionCachesAndContext(
+                header,
+                gateway,
+                renderer,
+                chrome,
+                inspectionSemantics);
             DynamicOwnershipReachesCommitPayload(backend, session);
             IncludeUsesTheAuthoritativeBaselineAndApplyPath(gateway, backend);
             LegacyPayloadsRemainFailClosed(gateway, backend, session);
@@ -43,7 +56,9 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
         private static void InspectionUsesRevisionCachesAndContext(
             string header,
             string gateway,
-            string renderer)
+            string renderer,
+            string chrome,
+            string inspectionSemantics)
         {
             TestAssert.Contains(
                 gateway,
@@ -115,8 +130,12 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
                 "cell inspection must enumerate the cached changed targets");
             TestAssert.Contains(
                 drawPath,
-                "DrawGlobalInspectionTarget(",
-                "global inspection changes must draw affected columns across visible rows");
+                "_inspectionGlobalColumns",
+                "global inspection changes must aggregate affected columns before row drawing");
+            TestAssert.Contains(
+                drawPath,
+                "_inspectionCellMasks",
+                "inspection changes must aggregate one semantic mask per visible cell");
             TestAssert.Contains(
                 drawPath,
                 "WorkGridInteractionGeometry.GetAnimatedBodyContentRect",
@@ -133,6 +152,30 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
                 renderer,
                 "WorkPriorityCellGeometry.GetDrawnPriorityBoxRect",
                 "priority inspection must use the authoritative drawn box geometry");
+            TestAssert.Contains(
+                renderer,
+                "GetSpecificColumns(target.WorkType, target.WorkGiver)",
+                "specific inspection targets must use the direct semantic index");
+            TestAssert.Contains(
+                renderer,
+                "GetOrderingColumns(target.WorkType)",
+                "ordering inspection targets must use the direct semantic index");
+            TestAssert.Contains(
+                renderer,
+                "right: true",
+                "ordering inspection must retain a distinct right-edge marker");
+            TestAssert.Contains(
+                inspectionSemantics,
+                "_values[key] = existing | kind",
+                "inspection semantic kinds must compose rather than use precedence");
+            TestAssert.Contains(
+                gateway,
+                "_hasManualModeInspectionChange",
+                "manual mode inspection must remain a single global semantic marker");
+            TestAssert.Contains(
+                chrome,
+                "GetManualPrioritiesCheckboxRect",
+                "manual-priority input and inspection geometry must share the chrome helper");
             TestAssert.Contains(
                 renderer,
                 "_inspectionBindingSubWorkRevision = subWorkRevision",

--- a/Tests/WorkloadsV2/GatewayMultiplayerTests.cs
+++ b/Tests/WorkloadsV2/GatewayMultiplayerTests.cs
@@ -312,8 +312,12 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
                 "receipt recovery must use the confirmed Save/Fork decision");
             TestAssert.Contains(
                 gateway,
-                "modern.RecoverPersistenceReceipt(decisionKind, targetStableId)",
+                "modern.RecoverPersistenceReceipt(\n                        decisionKind,\n                        targetStableId,\n                        forkLabel)",
                 "a terminal success without a receipt must ask the authoritative UI backend to recover it");
+            TestAssert.Contains(
+                completion,
+                "_multiplayerForkLabel",
+                "Save As receipt recovery must carry the requested fork label through completion");
             TestAssert.Contains(
                 backend,
                 "pending?.Result",
@@ -355,8 +359,12 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
                 "receipt recovery must reject non-authoritative persistence metadata");
             TestAssert.Contains(
                 recovery,
-                "The current V2 persistence revision is not the authoritative post-write revision.",
-                "receipt recovery must reject stale or ambiguous post-write revisions");
+                "baseline.PersistenceRevision",
+                "receipt recovery must pass the captured persistence revision to the pure seam");
+            TestAssert.Contains(
+                recovery,
+                "WorkloadPersistenceReceiptRecovery.TryRecover(",
+                "receipt recovery must retain fail-closed revision and identity validation in production code");
             TestAssert.False(
                 recovery.IndexOf("CaptureLiveBaseline", StringComparison.Ordinal) >= 0 ||
                 recovery.IndexOf("RebasePreviewAfterPersistence", StringComparison.Ordinal) >= 0 ||

--- a/Tests/WorkloadsV2/InspectionSemanticsTests.cs
+++ b/Tests/WorkloadsV2/InspectionSemanticsTests.cs
@@ -1,0 +1,108 @@
+using Better_Work_Tab.Features.Workloads.V2;
+
+namespace BetterWorkTab.WorkloadsV2.Deterministic
+{
+    internal static class InspectionSemanticsTests
+    {
+        public static void Run()
+        {
+            DirectColumnIndexesPreserveDuplicates();
+            CompoundMasksComposeAndDeduplicate();
+            ManualModeUsesOneEffectiveGlobalValue();
+        }
+
+        private static void DirectColumnIndexesPreserveDuplicates()
+        {
+            var index = new WorkloadInspectionColumnIndex();
+            index.Add(2, "PlantWork", null, true);
+            index.Add(7, "PlantWork", "PlantCut", true);
+            index.Add(11, "PlantWork", "PlantCut", true);
+            index.Add(13, "PlantWork", "PlantCut", false);
+            index.Add(17, "Cook", null, true);
+
+            TestAssert.Sequence(
+                new[] { 2 },
+                index.GetParentColumns("PlantWork"),
+                "Parent lookup should contain only parent priority columns.");
+            TestAssert.Sequence(
+                new[] { 7, 11 },
+                index.GetSpecificColumns("PlantWork", "PlantCut"),
+                "Specific lookup should preserve duplicate projected columns.");
+            TestAssert.Sequence(
+                new[] { 2, 7, 11 },
+                index.GetOrderingColumns("PlantWork"),
+                "Ordering lookup should include every parent and specific column.");
+            TestAssert.Sequence(
+                new[] { 17 },
+                index.GetOrderingColumns("Cook"),
+                "Ordering lookup should remain keyed by canonical WorkType defName.");
+        }
+
+        private static void CompoundMasksComposeAndDeduplicate()
+        {
+            var masks = new WorkloadInspectionCellMasks();
+            masks.Add(3, 9, WorkloadInspectionCellKind.ParentPriority);
+            masks.Add(3, 9, WorkloadInspectionCellKind.Schedule);
+            masks.Add(3, 9, WorkloadInspectionCellKind.Ordering);
+            masks.Add(3, 9, WorkloadInspectionCellKind.SpecificPriority);
+            masks.Add(3, 9, WorkloadInspectionCellKind.Schedule);
+
+            WorkloadInspectionCellKind kind;
+            TestAssert.True(
+                masks.TryGet(3, 9, out kind),
+                "A composed inspection cell should be present.");
+            TestAssert.Equal(
+                WorkloadInspectionCellKind.ParentPriority |
+                    WorkloadInspectionCellKind.SpecificPriority |
+                    WorkloadInspectionCellKind.Schedule |
+                    WorkloadInspectionCellKind.Ordering,
+                kind,
+                "All semantic flags should compose on one cell.");
+            TestAssert.Equal(
+                1,
+                masks.Count,
+                "Duplicate semantic targets should produce one draw mask.");
+        }
+
+        private static void ManualModeUsesOneEffectiveGlobalValue()
+        {
+            WorkloadParentPriorityKey beforeKey = new WorkloadParentPriorityKey(
+                TestSupport.Pawn("p1"),
+                TestSupport.WorkType("PlantWork"));
+            WorkloadParentPriorityKey retainedKey = new WorkloadParentPriorityKey(
+                TestSupport.Pawn("p2"),
+                TestSupport.WorkType("Cook"));
+            WorkloadParentPriorityKey addedKey = new WorkloadParentPriorityKey(
+                TestSupport.Pawn("p3"),
+                TestSupport.WorkType("Research"));
+
+            var before = new WorkloadProjectedState(
+                manualModes: new[]
+                {
+                    new WorkloadManualModeEntry(beforeKey, true),
+                    new WorkloadManualModeEntry(retainedKey, true)
+                });
+            var sameEffectiveModeAfterMembershipChurn = new WorkloadProjectedState(
+                manualModes: new[]
+                {
+                    new WorkloadManualModeEntry(retainedKey, true),
+                    new WorkloadManualModeEntry(addedKey, true)
+                });
+            var changed = new WorkloadProjectedState(
+                manualModes: new[]
+                {
+                    new WorkloadManualModeEntry(retainedKey, false),
+                    new WorkloadManualModeEntry(addedKey, false)
+                });
+
+            TestAssert.False(
+                WorkloadInspectionSemantics.HasEffectiveManualModeChange(
+                    before,
+                    sameEffectiveModeAfterMembershipChurn),
+                "Membership key churn with the same effective mode is not a global change.");
+            TestAssert.True(
+                WorkloadInspectionSemantics.HasEffectiveManualModeChange(before, changed),
+                "A changed effective manual mode should produce one global semantic marker.");
+        }
+    }
+}

--- a/Tests/WorkloadsV2/PersistenceReceiptRecoveryTests.cs
+++ b/Tests/WorkloadsV2/PersistenceReceiptRecoveryTests.cs
@@ -1,0 +1,276 @@
+using System;
+using Better_Work_Tab.Features.Workloads.V2;
+using Better_Work_Tab.Features.Workloads.V2.Runtime;
+
+namespace BetterWorkTab.WorkloadsV2.Deterministic
+{
+    internal static class PersistenceReceiptRecoveryTests
+    {
+        public static void Run()
+        {
+            UpdateRecoveryFromAuthoritativeSnapshotRebasesWithoutLiveRecapture();
+            ForkRecoveryFromAuthoritativeSnapshotUsesForkIdentity();
+            WrongForkLabelIsRejected();
+            WrongForkIdIsRejected();
+            StalePersistenceRevisionIsRejected();
+            WrongPersistedTargetIdentityIsRejected();
+        }
+
+        private static void UpdateRecoveryFromAuthoritativeSnapshotRebasesWithoutLiveRecapture()
+        {
+            WorkloadSession session = OpenEditedSession(out WorkloadSemanticDiff liveDiff);
+            WorkloadTemplate target = session.TargetTemplate;
+            WorkloadPersistenceRecoverySnapshot snapshot =
+                new WorkloadPersistenceRecoverySnapshot(
+                    target,
+                    8,
+                    "after-update",
+                    session.SourceTemplate.StableId);
+
+            WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
+                WorkloadPersistenceReceiptRecovery.TryRecover(
+                    session,
+                    WorkloadDecisionKind.Update,
+                    session.SourceTemplate.StableId,
+                    null,
+                    7,
+                    "before-update",
+                    snapshot);
+
+            TestAssert.True(
+                recovered.Succeeded && recovered.Value != null,
+                "Update recovery must construct a receipt from the authoritative snapshot");
+            TestAssert.True(
+                session.IsDirty,
+                "receipt recovery must not mutate the active preview before rebase validation");
+
+            WorkloadSession rebased = session.RebaseAfterPersistence(recovered.Value);
+            TestAssert.NotNull(
+                rebased,
+                "a recovered Update receipt must be accepted by the session rebase seam");
+            TestAssert.True(
+                rebased.TemplateDiff.IsEmpty,
+                "a recovered Update receipt must leave the template diff clean");
+            TestAssert.Equal(
+                liveDiff.BeforeFingerprint,
+                rebased.LiveDiff.BeforeFingerprint,
+                "Update recovery must preserve the captured live baseline before Apply");
+            TestAssert.Equal(
+                liveDiff.AfterFingerprint,
+                rebased.LiveDiff.AfterFingerprint,
+                "Update recovery must preserve the projected live impact after Apply");
+        }
+
+        private static void ForkRecoveryFromAuthoritativeSnapshotUsesForkIdentity()
+        {
+            WorkloadSession session = OpenEditedSession(out WorkloadSemanticDiff liveDiff);
+            const string forkId = "forked-night-shift";
+            const string forkLabel = "Forked Night Shift";
+            WorkloadSessionDecision fork = session.Fork(forkId, forkLabel);
+            TestAssert.True(fork.Accepted, "the deterministic fork target must be valid");
+
+            WorkloadPersistenceRecoverySnapshot snapshot =
+                new WorkloadPersistenceRecoverySnapshot(
+                    fork.ResultTemplate,
+                    8,
+                    "after-fork",
+                    forkId);
+            WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
+                WorkloadPersistenceReceiptRecovery.TryRecover(
+                    session,
+                    WorkloadDecisionKind.Fork,
+                    forkId,
+                    forkLabel,
+                    7,
+                    "before-fork",
+                    snapshot);
+
+            TestAssert.True(
+                recovered.Succeeded && recovered.Value != null,
+                "Save As recovery must validate the fork target reconstructed with its label");
+            TestAssert.Equal(
+                WorkloadSession.GetSourceIdentity(fork.ResultTemplate),
+                recovered.Value.TargetIdentity,
+                "Save As recovery must preserve the new fork identity");
+
+            WorkloadSession rebased = session.RebaseAfterPersistence(recovered.Value);
+            TestAssert.NotNull(
+                rebased,
+                "a recovered Save As receipt must be accepted by the session rebase seam");
+            TestAssert.Equal(
+                forkId,
+                rebased.SourceTemplate.StableId,
+                "Save As recovery must adopt the persisted fork as the active preview template");
+            TestAssert.Equal(
+                forkLabel,
+                rebased.SourceTemplate.Label,
+                "Save As recovery must retain the persisted fork label");
+            TestAssert.True(
+                rebased.TemplateDiff.IsEmpty,
+                "a recovered Save As receipt must leave the template diff clean");
+            TestAssert.Equal(
+                liveDiff.BeforeFingerprint,
+                rebased.LiveDiff.BeforeFingerprint,
+                "Save As recovery must preserve the captured live baseline before Apply");
+            TestAssert.Equal(
+                liveDiff.AfterFingerprint,
+                rebased.LiveDiff.AfterFingerprint,
+                "Save As recovery must preserve the projected live impact after Apply");
+        }
+
+        private static void WrongForkLabelIsRejected()
+        {
+            WorkloadSession session = OpenEditedSession(out _);
+            WorkloadSessionDecision fork = session.Fork(
+                "forked-night-shift",
+                "Persisted Fork Label");
+            WorkloadPersistenceRecoverySnapshot snapshot =
+                new WorkloadPersistenceRecoverySnapshot(
+                    fork.ResultTemplate,
+                    8,
+                    "after-fork",
+                    fork.ResultTemplate.StableId);
+
+            WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
+                WorkloadPersistenceReceiptRecovery.TryRecover(
+                    session,
+                    WorkloadDecisionKind.Fork,
+                    fork.ResultTemplate.StableId,
+                    "Wrong Fork Label",
+                    7,
+                    "before-fork",
+                    snapshot);
+
+            TestAssert.False(
+                recovered.Succeeded,
+                "recovery must reject a persisted fork whose label does not match the transaction target");
+        }
+
+        private static void WrongForkIdIsRejected()
+        {
+            WorkloadSession session = OpenEditedSession(out _);
+            WorkloadSessionDecision fork = session.Fork(
+                "persisted-fork-id",
+                "Persisted Fork");
+            WorkloadPersistenceRecoverySnapshot snapshot =
+                new WorkloadPersistenceRecoverySnapshot(
+                    fork.ResultTemplate,
+                    8,
+                    "after-fork",
+                    fork.ResultTemplate.StableId);
+
+            WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
+                WorkloadPersistenceReceiptRecovery.TryRecover(
+                    session,
+                    WorkloadDecisionKind.Fork,
+                    "different-requested-id",
+                    "Persisted Fork",
+                    7,
+                    "before-fork",
+                    snapshot);
+
+            TestAssert.False(
+                recovered.Succeeded,
+                "recovery must reject a persisted fork whose stable ID differs from the transaction target");
+        }
+
+        private static void StalePersistenceRevisionIsRejected()
+        {
+            WorkloadSession session = OpenEditedSession(out _);
+            WorkloadPersistenceRecoverySnapshot snapshot =
+                new WorkloadPersistenceRecoverySnapshot(
+                    session.TargetTemplate,
+                    7,
+                    "after-update",
+                    session.SourceTemplate.StableId);
+
+            WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
+                WorkloadPersistenceReceiptRecovery.TryRecover(
+                    session,
+                    WorkloadDecisionKind.Update,
+                    session.SourceTemplate.StableId,
+                    null,
+                    7,
+                    "before-update",
+                    snapshot);
+
+            TestAssert.False(
+                recovered.Succeeded,
+                "recovery must reject a snapshot that does not prove the post-write revision");
+        }
+
+        private static void WrongPersistedTargetIdentityIsRejected()
+        {
+            WorkloadSession session = OpenEditedSession(out _);
+            WorkloadTemplate expected = session.TargetTemplate;
+            WorkloadTemplate wrongTarget = expected.WithDefinition(
+                new WorkloadDefinition(
+                    expected.StableId,
+                    "Wrong persisted label",
+                    expected.SchemaVersion,
+                    expected.Definition.OwnershipDimensions,
+                    expected.Definition.Scope));
+            WorkloadPersistenceRecoverySnapshot snapshot =
+                new WorkloadPersistenceRecoverySnapshot(
+                    wrongTarget,
+                    8,
+                    "after-update",
+                    expected.StableId);
+
+            WorkloadOperationResult<WorkloadPersistenceReceipt> recovered =
+                WorkloadPersistenceReceiptRecovery.TryRecover(
+                    session,
+                    WorkloadDecisionKind.Update,
+                    expected.StableId,
+                    null,
+                    7,
+                    "before-update",
+                    snapshot);
+
+            TestAssert.False(
+                recovered.Succeeded,
+                "recovery must reject a target record whose canonical identity is wrong");
+        }
+
+        private static WorkloadSession OpenEditedSession(out WorkloadSemanticDiff liveDiff)
+        {
+            WorkloadParentPriorityKey key = new WorkloadParentPriorityKey(
+                TestSupport.Pawn("p1"),
+                TestSupport.WorkType("PlantWork"));
+            WorkloadProjectedState sourceState = State(key, 3);
+            WorkloadProjectedState liveState = State(key, 2);
+            WorkloadTemplate template = TestSupport.Template(sourceState);
+            WorkloadSession session = WorkloadSession.OpenCaptured(
+                template,
+                liveState,
+                WorkloadSession.GetSourceIdentity(template));
+            WorkloadSession edited = session.Edit(draft =>
+                draft.SetParentPriorityIntent(
+                    key,
+                    WorkloadIntent<WorkloadSpecificPriorityPayload>.CreateSet(
+                        new WorkloadSpecificPriorityPayload(4))));
+            liveDiff = edited.LiveDiff;
+            return edited;
+        }
+
+        private static WorkloadProjectedState State(
+            WorkloadParentPriorityKey key,
+            int priority)
+        {
+            return new WorkloadProjectedState(
+                parentPriorities: new[]
+                {
+                    new WorkloadParentPriorityEntry(key, priority)
+                },
+                parentPriorityIntents: new[]
+                {
+                    TestSupport.ParentPriorityIntent(
+                        key.Pawn,
+                        key.WorkType,
+                        WorkloadIntentState.Set,
+                        priority)
+                },
+                representedPawnIds: new[] { key.Pawn });
+        }
+    }
+}

--- a/Tests/WorkloadsV2/Program.cs
+++ b/Tests/WorkloadsV2/Program.cs
@@ -10,6 +10,8 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
             new TestCase("projection-and-settings", ProjectionAndSettingsTests.Run),
             new TestCase("specific-jobs-and-tombstones", SpecificJobTests.Run),
             new TestCase("session-lifecycle", SessionTests.Run),
+            new TestCase("persistence-receipt-recovery", PersistenceReceiptRecoveryTests.Run),
+            new TestCase("inspection-semantics", InspectionSemanticsTests.Run),
             new TestCase("persistence-and-migration", PersistenceTests.Run),
             new TestCase("reassignment-cleanup", ReassignmentCleanupTests.Run),
             new TestCase("mp-protocol", MpProtocolTests.Run),

--- a/Tests/WorkloadsV2/WorkloadsV2.Deterministic.csproj
+++ b/Tests/WorkloadsV2/WorkloadsV2.Deterministic.csproj
@@ -34,7 +34,9 @@
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadKeys.cs" Link="Production\WorkloadKeys.cs" />
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadDefinition.cs" Link="Production\WorkloadDefinition.cs" />
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadScope.cs" Link="Production\WorkloadScope.cs" />
+    <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadInspectionSemantics.cs" Link="Production\WorkloadInspectionSemantics.cs" />
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadMembership.cs" Link="Production\WorkloadMembership.cs" />
+    <Compile Include="..\..\Source\Features\Workloads\V2\Runtime\WorkloadPersistenceReceiptRecovery.cs" Link="Production\WorkloadPersistenceReceiptRecovery.cs" />
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadState.cs" Link="Production\WorkloadState.cs" />
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadDiff.cs" Link="Production\WorkloadDiff.cs" />
     <Compile Include="..\..\Source\Features\Workloads\V2\WorkloadValidation.cs" Link="Production\WorkloadValidation.cs" />
@@ -62,6 +64,8 @@
     <Compile Include="ProjectionAndSettingsTests.cs" />
     <Compile Include="SpecificJobTests.cs" />
     <Compile Include="SessionTests.cs" />
+    <Compile Include="PersistenceReceiptRecoveryTests.cs" />
+    <Compile Include="InspectionSemanticsTests.cs" />
     <Compile Include="PersistenceTests.cs" />
     <Compile Include="ReassignmentCleanupTests.cs" />
     <Compile Include="MpProtocolTests.cs" />


### PR DESCRIPTION
## Summary
- recover null-result multiplayer Save As receipts against the exact persisted fork ID and label
- replace inspection target-by-column scans with direct cached layout indexes and composed cell masks
- preserve simultaneous priority, schedule, and ordering visuals; show manual-priority mode once at its checkbox
- add executable recovery, rebase, inspection-index, compound-mask, and manual-mode tests

## Verification
- Workloads V2 deterministic: 12/12 passed
- external deterministic suite: 231 passed, 0 failed
- service contract tests: 13 passed, 0 failed
- authoritative BWT verifier: 18/18 steps passed
- embedded and external-Spine 1.6 candidate builds passed
- API contracts and production-surface gates passed
- horizontal-scroll assembly contract: 44 checks passed
- harness runtime gameplay checks passed; evidence remained log-red only for the smoke pack's known missing BWT_WorkRules, BWT_SpecificJobs, and BWT_RuleSuggestions ConceptDefs