### PR TITLE
Preserve mixed schedule inspection markers

### DIFF
--- a/Source/UI/WorkGrid/Rendering/WorkTabBodyRenderer.cs
+++ b/Source/UI/WorkGrid/Rendering/WorkTabBodyRenderer.cs
@@ -685,18 +685,18 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
                 return;
             }
 
+            if (preview.HasInspectionRowLevelChanges)
+            {
+                DrawWorkloadInspectionRows(
+                    rowDescriptors,
+                    totalWidth,
+                    rowGeometry,
+                    visibleRows,
+                    preview);
+            }
+
             if (!preview.HasInspectionCellTargets)
             {
-                if (preview.HasInspectionRowLevelChanges)
-                {
-                    DrawWorkloadInspectionRows(
-                        rowDescriptors,
-                        totalWidth,
-                        rowGeometry,
-                        visibleRows,
-                        preview);
-                }
-
                 // Membership-only and presentation-only changes are rendered
                 // by their own paths (or have no grid visual). Do not walk the
                 // body columns for them.

--- a/Tests/WorkloadsV2/GatewayLifecycleTests.cs
+++ b/Tests/WorkloadsV2/GatewayLifecycleTests.cs
@@ -124,6 +124,14 @@ namespace BetterWorkTab.WorkloadsV2.Deterministic
                 drawPath,
                 "preview.IsInspectionRowLevelChanged(descriptor.Pawn)",
                 "legacy schedule-only inspection must draw only affected visible rows");
+            TestAssert.True(
+                drawPath.IndexOf(
+                    "preview.HasInspectionRowLevelChanges",
+                    StringComparison.Ordinal) <
+                drawPath.IndexOf(
+                    "if (!preview.HasInspectionCellTargets)",
+                    StringComparison.Ordinal),
+                "row-level schedule inspection must run even when normal cell targets also exist");
             TestAssert.Contains(
                 drawPath,
                 "preview.InspectionTargets",


### PR DESCRIPTION
## Summary
- always draw cached row-level legacy schedule inspection markers while inspection is active
- retain the no-cell fast return before any semantic column binding or cell-mask work
- add a lifecycle source contract covering mixed row-level schedule and normal cell changes

## Verification
- Workloads V2 deterministic: 12/12 passed
- authoritative BWT verifier: 18/18 steps passed
- external deterministic: 231 passed, 0 failed
- service contracts: 13 passed, 0 failed
- embedded and external-Spine 1.6 builds passed