### PR TITLE
Clean up player-facing text

### DIFF
--- a/0.13/About/About.xml
+++ b/0.13/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.13.1137</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.13 -> v1.1 - Multiplayer does not work

--- a/0.14/About/About.xml
+++ b/0.14/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.14.1249</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.14 -> v1.1 - Multiplayer does not work

--- a/0.15/About/About.xml
+++ b/0.15/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.15.1284</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.15 -> v1.1 - Multiplayer does not work

--- a/0.16/About/About.xml
+++ b/0.16/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.16.1393</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.16 -> v1.1 - Multiplayer does not work

--- a/0.17/About/About.xml
+++ b/0.17/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.17.1557</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.17 -> v1.1 - Multiplayer does not work

--- a/0.18/About/About.xml
+++ b/0.18/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.18.1722</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.18 -> v1.1 - Multiplayer does not work

--- a/0.19/About/About.xml
+++ b/0.19/About/About.xml
@@ -4,9 +4,9 @@
   <author>Coolnether123</author>
   <url>https://github.com/coolnether123/Better-Work-Tab</url>
   <targetVersion>0.19.2009</targetVersion>
-  <description><![CDATA[Better Work Tab v1.1 overhauls RimWorld's Work tab with drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization.
+  <description><![CDATA[Better Work Tab v1.1 adds drag-and-drop ordering, skill overlays, automation rules, extended priorities up to 99, workloads, dividers, and visual customization to RimWorld's Work tab.
 
-Features are toggleable in settings.
+You can toggle features in settings.
 
 Version support:
 - 0.19 -> v1.1 - Multiplayer does not work

--- a/About/About.xml
+++ b/About/About.xml
@@ -21,14 +21,14 @@
   </supportedVersions>
  <packageId>Coolnether123.BetterWorkTab</packageId>
  <modVersion>2.0.0</modVersion>
-  <description><![CDATA[Better Work Tab v2.0 overhauls RimWorld's Work tab with drag-and-drop, skill overlays, automation rules, sub-work jobs, time priority schedules, extended priorities, and visual customization.
+  <description><![CDATA[Better Work Tab v2.0 adds drag-and-drop ordering, skill overlays, automation rules, sub-work jobs, time priority schedules, extended priorities, and visual customization to RimWorld's Work tab.
 
-All features are toggleable in settings with extensive customization options.
+You can toggle features in settings.
 
 <b>Features</b>
 - Drag and drop work column and pawn row reordering
 - Extended max priorities from vanilla 4 up to 99
-- Sub-work job drilldown with global and pawn-specific priorities
+- Specific-job view with shared and pawn-specific priorities
 - Time-of-day priority schedules for work and sub-work jobs
 - Skill level overlay (hold SHIFT)
 - Auto-assignment rulesets
@@ -40,14 +40,14 @@ All features are toggleable in settings with extensive customization options.
 - Colonist and bed counts
 - Right-click pawn quick actions
 - Multiplayer support for supported versions with Zetrith Multiplayer
-- Detailed settings for UI, priorities, rules, workloads, and layout
-- Optional Fluffy-style layout with right-expanding specific jobs; installed Fluffy icons are used for its top controls, with an off-by-default BWT substitute available standalone
+- Settings for UI, priorities, rules, workloads, and layout
+- Optional Fluffy-style layout with right-expanding specific jobs. It uses installed Fluffy icons for top controls, with an off-by-default BWT text substitute available without Fluffy
 
 <b>Compatibility</b>
 - Compatible with most work-type mods
 - [FSF] Complex Jobs column ordering is supported
 - Vanilla Skills Expanded passion types are supported in rule conditions when the mod is active
-- Do Once - Noncommittal Work is compatible; BWT suppresses its duplicate borrowed menu patches and uses BWT's sub-work-aware version
+- Do Once - Noncommittal Work is compatible. BWT suppresses its duplicate borrowed menu patches and uses BWT's specific-job-aware version
 - Useful Marks markers appear on pawn icons when available
 - Grouped Pawns List is overridden inside this Work tab
 - CompactWorkTab overlaps this UI and should not be used together
@@ -55,10 +55,10 @@ All features are toggleable in settings with extensive customization options.
 
 <b>Credits and licensing</b>
 - Fluffy's Work Tab by Fluffy inspired the Fluffy-style layout and remains supported as an optional compatibility target
-- Fluffy Work Tab software/documentation is MIT licensed; its art and sounds are not bundled with BWT
+- Fluffy Work Tab software and documentation are MIT licensed. Its art and sounds are not bundled with BWT
 - Full notices: https://github.com/coolnether123/Better-Work-Tab/blob/Dev/THIRD_PARTY_NOTICES.md
 
-<b>Version Support</b>
+<b>Version support</b>
 - 1.6 -> v2.0
 - 1.5 -> v2.0
 - 1.4 -> v2.0

--- a/Defs/ConceptDefs/Concepts_BetterWorkTab.xml
+++ b/Defs/ConceptDefs/Concepts_BetterWorkTab.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <!--=========== Better Work Tab's help, taught through RimWorld's own learning
-       readout when the relevant window opens.
+  <!--=========== Better Work Tab help appears in RimWorld's learning readout
+       when the relevant window opens.
 
-       Written to vanilla's shape deliberately: one or two short beats separated
-       by a blank line, the key noun in capitals, and the action last. These sit
-       in the same box as CameraDolly and Stockpiles, so anything longer or
-       chattier than those reads as a different mod talking over the game.
+       Each entry follows the vanilla format: one or two short passages, a key
+       noun in capitals, and the action last. These entries appear beside
+       CameraDolly and Stockpiles.
 
-       needsOpportunity keeps them out of the readout until something actually
-       registers one, so a player who never opens the Rule Builder is never
-       taught about rules. ============================================-->
+       needsOpportunity keeps an entry out of the readout until something
+       registers it. Players who do not open the Rule Builder do not see rule
+       guidance. ============================================-->
 
   <ConceptDef Abstract="True" Name="BWT_OpportunityConceptBase">
     <priority>50</priority>
@@ -27,7 +26,7 @@
   <ConceptDef ParentName="BWT_OpportunityConceptBase">
     <defName>BWT_SpecificJobs</defName>
     <label>Specific jobs</label>
-    <helpText>Every Work type is made of smaller jobs. Ctrl-click a Work type's header to set priorities for one SPECIFIC JOB instead of the whole thing.</helpText>
+    <helpText>Every Work type contains smaller jobs. Ctrl-click a Work type's header to set priorities for one SPECIFIC JOB instead of the whole Work type.</helpText>
   </ConceptDef>
 
   <ConceptDef ParentName="BWT_OpportunityConceptBase">

--- a/Languages/English/Keyed/BWT_Settings.xml
+++ b/Languages/English/Keyed/BWT_Settings.xml
@@ -6,7 +6,7 @@
     <BWT_Settings_UI_Settings>Settings</BWT_Settings_UI_Settings>
     <BWT_Settings_UI_Controls>Controls</BWT_Settings_UI_Controls>
     <BWT_Settings_UI_Edit>Edit</BWT_Settings_UI_Edit>
-    <BWT_Settings_UI_AdvancedSearchNotice>Found in Advanced settings: {0} — click to switch to Advanced</BWT_Settings_UI_AdvancedSearchNotice>
+    <BWT_Settings_UI_AdvancedSearchNotice>Found in Advanced settings: {0}. Click to switch to Advanced.</BWT_Settings_UI_AdvancedSearchNotice>
     <BWT_Settings_UI_Close>Close</BWT_Settings_UI_Close>
     <BWT_Settings_UI_CurrentSelection>Currently selected</BWT_Settings_UI_CurrentSelection>
     <BWT_Settings_UI_PreviewingOption>Previewing option</BWT_Settings_UI_PreviewingOption>
@@ -16,13 +16,15 @@
     <BWT_Enum_SubWorkDrilldownModifier_Shift_Description>Use Shift plus the configured mouse button for specific jobs. This may conflict with skill displays and column grouping.</BWT_Enum_SubWorkDrilldownModifier_Shift_Description>
     <BWT_Enum_SubWorkDrilldownButton_Left_Description>Use the left mouse button with the configured modifier to enter or leave the specific-job view.</BWT_Enum_SubWorkDrilldownButton_Left_Description>
     <BWT_Enum_SubWorkDrilldownButton_Right_Description>Use the right mouse button with the configured modifier to enter or leave the specific-job view.</BWT_Enum_SubWorkDrilldownButton_Right_Description>
-    <BWT_Enum_SubWorkDrilldownStyle_NotChosen_Description>No specific-job presentation has been selected yet. Better Work Tab will ask for a choice before opening that view.</BWT_Enum_SubWorkDrilldownStyle_NotChosen_Description>
+    <BWT_Enum_SubWorkDrilldownStyle_NotChosen_Description>No specific-job layout has been selected yet. Better Work Tab will ask before opening that view.</BWT_Enum_SubWorkDrilldownStyle_NotChosen_Description>
     <BWT_Enum_SubWorkDrilldownStyle_FocusView_Description>Opens the chosen work type in a focused full-tab view containing only its specific jobs.</BWT_Enum_SubWorkDrilldownStyle_FocusView_Description>
     <BWT_Enum_SubWorkDrilldownStyle_ExpandBeside_Description>Expands the chosen work type's specific-job columns beside the parent column in the main Work table.</BWT_Enum_SubWorkDrilldownStyle_ExpandBeside_Description>
     <BWT_Enum_SubWorkTransitionStyle_ClassicGlideFlash_Description>Slides specific-job columns into position and uses a brief flash during the transition.</BWT_Enum_SubWorkTransitionStyle_ClassicGlideFlash_Description>
     <BWT_Enum_SubWorkTransitionStyle_PixelWaveFlip_Description>Keeps columns in position while a grey pixel wave progressively reveals or hides the specific-job view.</BWT_Enum_SubWorkTransitionStyle_PixelWaveFlip_Description>
+    <BWT_SubWorkTransition_Off>Off (instant)</BWT_SubWorkTransition_Off>
+    <BWT_SubWorkTransition_Off_Description>Turns off the specific-job transition animation. Columns change immediately when you enter or leave the specific-job view.</BWT_SubWorkTransition_Off_Description>
     <BWT_Enum_SubWorkDisabledParentMode_ParentWorkDisablesSubWork_Description>Vanilla behavior: disabling a Work type also disables its specific jobs, including locked priorities.</BWT_Enum_SubWorkDisabledParentMode_ParentWorkDisablesSubWork_Description>
-    <BWT_Enum_SubWorkDisabledParentMode_LockedSubWorkOverridesParent_Description>In singleplayer, locked specific jobs can run while their parent is disabled. Multiplayer keeps vanilla parent-disable behavior for determinism.</BWT_Enum_SubWorkDisabledParentMode_LockedSubWorkOverridesParent_Description>
+    <BWT_Enum_SubWorkDisabledParentMode_LockedSubWorkOverridesParent_Description>In singleplayer, locked specific jobs can run while their parent is disabled. Multiplayer keeps vanilla behavior so every player gets the same result.</BWT_Enum_SubWorkDisabledParentMode_LockedSubWorkOverridesParent_Description>
     <BWT_Enum_PriorityMode_Vanilla_Description>Uses RimWorld's standard priority range and behavior. Better Work Tab does not own or expand the priority range.</BWT_Enum_PriorityMode_Vanilla_Description>
     <BWT_Enum_PriorityMode_Auto_Description>Uses vanilla priorities by default, then safely adopts a compatible expanded range when another provider or existing high priorities require it.</BWT_Enum_PriorityMode_Auto_Description>
     <BWT_Enum_PriorityMode_ExternalProvider_Description>Delegates the priority range to the selected compatible external provider. Better Work Tab presents and edits the values supplied by that provider.</BWT_Enum_PriorityMode_ExternalProvider_Description>
@@ -36,9 +38,9 @@
     <BWT_Enum_SkillViewHoverMode_Standard_Description>Keeps priority as the main cell value and shows skill information as the smaller secondary value, matching the priority-focused Work-tab interaction.</BWT_Enum_SkillViewHoverMode_Standard_Description>
     <BWT_Enum_SkillViewHoverMode_SkillFocused_Description>Makes the skill level the large central value and moves priority to the smaller corner value while the hover effect is active.</BWT_Enum_SkillViewHoverMode_SkillFocused_Description>
     <BWT_Enum_SkillViewHoverMode_None_Description>Does not change cell contents on hover. The normal priority and configured skill overlays remain as they were.</BWT_Enum_SkillViewHoverMode_None_Description>
-    <BWT_Enum_HoverEffectScope_CellOnly_Description>Applies the configured priority/skill hover presentation only to the single work cell under the pointer.</BWT_Enum_HoverEffectScope_CellOnly_Description>
-    <BWT_Enum_HoverEffectScope_ColumnWide_Description>Applies the configured priority/skill hover presentation to every visible pawn cell in the work column under the pointer.</BWT_Enum_HoverEffectScope_ColumnWide_Description>
-    <BWT_Enum_WorkGridRendererMode_Auto_Description>Uses the optimized renderer when compatible; otherwise, the Work grid falls back to vanilla. Other Better Work Tab features remain active.</BWT_Enum_WorkGridRendererMode_Auto_Description>
+    <BWT_Enum_HoverEffectScope_CellOnly_Description>Shows the configured priority and skill hover effect only in the cell under the pointer.</BWT_Enum_HoverEffectScope_CellOnly_Description>
+    <BWT_Enum_HoverEffectScope_ColumnWide_Description>Shows the configured priority and skill hover effect in every visible pawn cell in the column under the pointer.</BWT_Enum_HoverEffectScope_ColumnWide_Description>
+    <BWT_Enum_WorkGridRendererMode_Auto_Description>Uses the optimized renderer when compatible. Otherwise, the Work grid falls back to vanilla. Other Better Work Tab features remain active.</BWT_Enum_WorkGridRendererMode_Auto_Description>
     <BWT_Enum_WorkGridRendererMode_Optimized_Description>Uses the optimized layered renderer. If a safety check fails, the Work grid falls back to vanilla.</BWT_Enum_WorkGridRendererMode_Optimized_Description>
     <BWT_Enum_WorkGridRendererMode_Vanilla_Description>Always uses RimWorld's native Work-grid renderer. Better Work Tab's other enabled features remain available around that vanilla rendering path.</BWT_Enum_WorkGridRendererMode_Vanilla_Description>
     <BWT_Enum_RulesetViewMode_Raw>Classic list</BWT_Enum_RulesetViewMode_Raw>
@@ -47,8 +49,8 @@
     <BWT_Enum_RulesetViewMode_Regular_Description>Shows the guided visual rule builder as the ruleset editor.</BWT_Enum_RulesetViewMode_Regular_Description>
     <BWT_Enum_RulesetViewMode_Both>Both</BWT_Enum_RulesetViewMode_Both>
     <BWT_Enum_RulesetViewMode_Both_Description>Makes both the visual rule builder and classic ruleset list available so the player can choose either workflow.</BWT_Enum_RulesetViewMode_Both_Description>
-    <BWT_Enum_WorkTabOwnerPreference_BetterWorkTab_Description>Keeps Better Work Tab in control of the Work tab and its compatibility infrastructure.</BWT_Enum_WorkTabOwnerPreference_BetterWorkTab_Description>
-    <BWT_Enum_WorkTabOwnerPreference_FluffyWorkTab_Description>Hands the Work tab to Fluffy's Work Tab while Better Work Tab contains its own conflicting presentation features.</BWT_Enum_WorkTabOwnerPreference_FluffyWorkTab_Description>
+    <BWT_Enum_WorkTabOwnerPreference_BetterWorkTab_Description>Keeps Better Work Tab in control of the Work tab and compatibility features.</BWT_Enum_WorkTabOwnerPreference_BetterWorkTab_Description>
+    <BWT_Enum_WorkTabOwnerPreference_FluffyWorkTab_Description>Hands the Work tab to Fluffy's Work Tab and hides conflicting Better Work Tab display features.</BWT_Enum_WorkTabOwnerPreference_FluffyWorkTab_Description>
     <BWT_Enum_WorkTabOwnerPreference_SleekWorkPriorities>Sleek Work Priorities</BWT_Enum_WorkTabOwnerPreference_SleekWorkPriorities>
      <BWT_Enum_WorkTabOwnerPreference_SleekWorkPriorities_Description>Hands the complete Work tab to Sleek Work Priorities, including its grid, groups, focus cards, and per-job priority features.</BWT_Enum_WorkTabOwnerPreference_SleekWorkPriorities_Description>
      <BWT_Enum_WorkTabOwnerPreference_BetterWorkTabWithSleekWorkPriorities>Better Work Tab + Sleek Work Priorities</BWT_Enum_WorkTabOwnerPreference_BetterWorkTabWithSleekWorkPriorities>
@@ -78,8 +80,120 @@
     <BWT_SleekChoice_SleekOnly>Use Sleek only</BWT_SleekChoice_SleekOnly>
     <BWT_Sleek_SettingsHint>Alt-click settings</BWT_Sleek_SettingsHint>
     <BWT_Sleek_SettingsHint_Tooltip>Open Better Work Tab settings without leaving Sleek's Work tab.</BWT_Sleek_SettingsHint_Tooltip>
-    <BWT_Sleek_FooterHint>Better Work Tab: right-click colonist names for organization; Alt-click for settings.</BWT_Sleek_FooterHint>
+    <BWT_Sleek_FooterHint>Better Work Tab: right-click colonist names to organize them. Alt-click for settings.</BWT_Sleek_FooterHint>
     <BWT_Settings_UI_PinnedSettings>★ Pinned Settings</BWT_Settings_UI_PinnedSettings>
+
+    <!-- Settings, dialogs, and Work tab -->
+    <BWT_Settings_UI_ColorPreviewTooltip>Hover here, or adjust the picker to preview this color on the Work tab.</BWT_Settings_UI_ColorPreviewTooltip>
+    <BWT_Settings_UI_Filter>Filter</BWT_Settings_UI_Filter>
+    <BWT_Settings_UI_AllSettings>All settings</BWT_Settings_UI_AllSettings>
+    <BWT_Dialog_None>(none)</BWT_Dialog_None>
+    <BWT_Dialog_Accept>Accept</BWT_Dialog_Accept>
+    <BWT_Dialog_UseDefault>Use default</BWT_Dialog_UseDefault>
+    <BWT_Dialog_PawnTitle_Title>Change pawn title</BWT_Dialog_PawnTitle_Title>
+    <BWT_Dialog_PawnTitle_Default>Default title: {0}</BWT_Dialog_PawnTitle_Default>
+    <BWT_Dialog_PawnTitle_BlankUsesDefault>Leave blank to use the default title.</BWT_Dialog_PawnTitle_BlankUsesDefault>
+    <BWT_Dialog_Divider_DefaultName>New divider</BWT_Dialog_Divider_DefaultName>
+    <BWT_Dialog_Divider_Title>Edit divider</BWT_Dialog_Divider_Title>
+    <BWT_Dialog_Divider_Color>Divider color</BWT_Dialog_Divider_Color>
+    <BWT_Dialog_Divider_ColorDisabled>Divider color (disabled)</BWT_Dialog_Divider_ColorDisabled>
+    <BWT_Dialog_Divider_ShowLabel>Show label</BWT_Dialog_Divider_ShowLabel>
+    <BWT_Dialog_Divider_TextSize>Text size: {0}</BWT_Dialog_Divider_TextSize>
+    <BWT_Dialog_Divider_Height>Height: {0:F0}px</BWT_Dialog_Divider_Height>
+    <BWT_Dialog_Divider_Thin>Thin</BWT_Dialog_Divider_Thin>
+    <BWT_Dialog_Divider_Tall>Tall</BWT_Dialog_Divider_Tall>
+    <BWT_Dialog_Font_Tiny>Tiny</BWT_Dialog_Font_Tiny>
+    <BWT_Dialog_Font_Small>Small</BWT_Dialog_Font_Small>
+    <BWT_Dialog_Font_Medium>Medium</BWT_Dialog_Font_Medium>
+    <BWT_Dialog_Workload_NameTitle>Name workload</BWT_Dialog_Workload_NameTitle>
+    <BWT_Chrome_BackToWorkTypesTooltip>Return to Work types. {0} or press Escape.</BWT_Chrome_BackToWorkTypesTooltip>
+    <BWT_Chrome_Colonists>Colonists: {0}</BWT_Chrome_Colonists>
+    <BWT_Chrome_Beds>Beds: {0}</BWT_Chrome_Beds>
+    <BWT_Chrome_AltClickSettings>Alt-click for settings</BWT_Chrome_AltClickSettings>
+    <BWT_Chrome_ManualPriorityPreviewWarning>This preview changes manual-priority mode for the whole game.</BWT_Chrome_ManualPriorityPreviewWarning>
+    <BWT_Context_InsertDividerAbove>Insert divider above</BWT_Context_InsertDividerAbove>
+    <BWT_Context_InsertDividerBelow>Insert divider below</BWT_Context_InsertDividerBelow>
+    <BWT_Context_SetBackgroundColor>Set background color...</BWT_Context_SetBackgroundColor>
+    <BWT_Context_ChangeTitle>Change title...</BWT_Context_ChangeTitle>
+    <BWT_Context_ClearBackgroundColor>Clear background color</BWT_Context_ClearBackgroundColor>
+    <BWT_Context_CopyPawnRow>Copy {0}'s row to my layout and stop following</BWT_Context_CopyPawnRow>
+    <BWT_Context_MembershipExcluded>Unavailable. Excluded by the saved workload.</BWT_Context_MembershipExcluded>
+    <BWT_Context_MembershipPawnUnavailable>Unavailable. Pawn is missing or out of date.</BWT_Context_MembershipPawnUnavailable>
+    <BWT_Context_IncludeInApplication>Include in this workload</BWT_Context_IncludeInApplication>
+    <BWT_Context_ExcludeFromApplication>Exclude from this workload</BWT_Context_ExcludeFromApplication>
+    <BWT_Context_MembershipOutsideScope>Unavailable. Outside the saved workload.</BWT_Context_MembershipOutsideScope>
+    <BWT_Context_MembershipUnavailable>Unavailable for this pawn</BWT_Context_MembershipUnavailable>
+    <BWT_Context_Edit>Edit...</BWT_Context_Edit>
+    <BWT_Context_CopyDivider>Copy this divider to my layout and stop following</BWT_Context_CopyDivider>
+    <BWT_Settings_OptionalMod_Required>Requires {0}.</BWT_Settings_OptionalMod_Required>
+    <BWT_Settings_OptionalMod_OpenWorkshop>Open Workshop</BWT_Settings_OptionalMod_OpenWorkshop>
+    <BWT_Settings_OptionalMod_WorkshopTooltip>Requires {0}. Open its Steam Workshop page.</BWT_Settings_OptionalMod_WorkshopTooltip>
+    <BWT_Settings_Json_FilePath>JSON file path</BWT_Settings_Json_FilePath>
+    <BWT_Settings_Json_DefaultFolder>Default folder: {0}</BWT_Settings_Json_DefaultFolder>
+    <BWT_Settings_Json_OpenFolder>Open folder</BWT_Settings_Json_OpenFolder>
+    <BWT_Settings_Json_InvalidPath>Enter a valid JSON file path.</BWT_Settings_Json_InvalidPath>
+    <BWT_Settings_ImportExport_Export>Export</BWT_Settings_ImportExport_Export>
+    <BWT_Settings_ImportExport_Import>Import</BWT_Settings_ImportExport_Import>
+    <BWT_Settings_ImportExport_File>File</BWT_Settings_ImportExport_File>
+    <BWT_Settings_ImportExport_Clipboard>Clipboard</BWT_Settings_ImportExport_Clipboard>
+    <BWT_Settings_ImportExport_Copied>Copied Better Work Tab settings to the clipboard.</BWT_Settings_ImportExport_Copied>
+    <BWT_Settings_ImportExport_ExportTitle>Export Better Work Tab settings</BWT_Settings_ImportExport_ExportTitle>
+    <BWT_Settings_ImportExport_Exported>Exported Better Work Tab settings to {0}.</BWT_Settings_ImportExport_Exported>
+    <BWT_Settings_ImportExport_ExportFailed>Couldn't export Better Work Tab settings. Check the log.</BWT_Settings_ImportExport_ExportFailed>
+    <BWT_Settings_ImportExport_ImportTitle>Import Better Work Tab settings</BWT_Settings_ImportExport_ImportTitle>
+    <BWT_Settings_ImportExport_FileMissing>That Better Work Tab settings file doesn't exist.</BWT_Settings_ImportExport_FileMissing>
+    <BWT_Settings_ImportExport_ImportFailed>Couldn't import Better Work Tab settings. Check the log.</BWT_Settings_ImportExport_ImportFailed>
+    <BWT_Settings_ImportExport_ConfirmImport>Importing replaces all Better Work Tab settings, including rules, layout state, viewed settings, and recent colors. Continue?</BWT_Settings_ImportExport_ConfirmImport>
+    <BWT_Settings_Search_AdvancedSetting>an Advanced setting</BWT_Settings_Search_AdvancedSetting>
+    <BWT_Settings_Search_MatchCount> ({0} matches)</BWT_Settings_Search_MatchCount>
+    <BWT_Settings_Search_HiddenInSimple>This result is hidden in Simple view. Switch to Advanced to show it.</BWT_Settings_Search_HiddenInSimple>
+    <BWT_Settings_Search_AdvancedContext>Advanced setting: {0}. Switch to Advanced to show it.</BWT_Settings_Search_AdvancedContext>
+    <BWT_Settings_Search_None>None</BWT_Settings_Search_None>
+    <BWT_Settings_Search_AliasStatus>{0} active, {1} pending</BWT_Settings_Search_AliasStatus>
+    <BWT_Settings_Search_Reset>Reset</BWT_Settings_Search_Reset>
+    <BWT_Settings_Search_AliasPrivacy>Better Work Tab waits for three repeated corrections before learning a local search alias. Search text stays on this computer.</BWT_Settings_Search_AliasPrivacy>
+    <BWT_Settings_Filter_SpecificJobs>Specific jobs</BWT_Settings_Filter_SpecificJobs>
+    <BWT_Settings_Filter_Headers>Headers</BWT_Settings_Filter_Headers>
+    <BWT_Settings_Filter_Dividers>Dividers</BWT_Settings_Filter_Dividers>
+    <BWT_Settings_Filter_DragDrop>Drag and drop</BWT_Settings_Filter_DragDrop>
+    <BWT_Settings_Filter_Priorities>Priorities</BWT_Settings_Filter_Priorities>
+    <BWT_Settings_Filter_HourlyPriorities>Hourly priorities</BWT_Settings_Filter_HourlyPriorities>
+    <BWT_Settings_Filter_FluffyStyle>Fluffy-style Work tab</BWT_Settings_Filter_FluffyStyle>
+    <BWT_Settings_Filter_Workloads>Workloads</BWT_Settings_Filter_Workloads>
+    <BWT_Settings_Filter_RuleBuilder>Rule Builder</BWT_Settings_Filter_RuleBuilder>
+    <BWT_Settings_Filter_Highlights>Highlights</BWT_Settings_Filter_Highlights>
+    <BWT_Settings_Filter_Display>Work tab display</BWT_Settings_Filter_Display>
+    <BWT_Settings_Filter_Controls>Controls and shortcuts</BWT_Settings_Filter_Controls>
+    <BWT_Settings_Filter_Presets>Presets</BWT_Settings_Filter_Presets>
+    <BWT_Settings_Filter_States>States</BWT_Settings_Filter_States>
+    <BWT_Settings_Filter_Systems>Systems</BWT_Settings_Filter_Systems>
+    <BWT_Settings_Filter_Versions>Versions</BWT_Settings_Filter_Versions>
+    <BWT_Settings_Filter_WorkTabStyle>Expanded Work tab</BWT_Settings_Filter_WorkTabStyle>
+    <BWT_Settings_Filter_WorkTabStyleTooltip>Show settings for compact headers, priorities, specific jobs, dividers, dragging, skill overlays, workloads, and hourly priorities.</BWT_Settings_Filter_WorkTabStyleTooltip>
+    <BWT_Settings_Filter_VanillaPlus>Vanilla+</BWT_Settings_Filter_VanillaPlus>
+    <BWT_Settings_Filter_VanillaPlusTooltip>Show settings that stay close to vanilla while adding headers, dragging, highlights, skill overlays, counts, priority display, and spacing.</BWT_Settings_Filter_VanillaPlusTooltip>
+    <BWT_Settings_Filter_Enabled>Enabled settings</BWT_Settings_Filter_Enabled>
+    <BWT_Settings_Filter_EnabledTooltip>Show enabled on/off settings only.</BWT_Settings_Filter_EnabledTooltip>
+    <BWT_Settings_Filter_Disabled>Disabled settings</BWT_Settings_Filter_Disabled>
+    <BWT_Settings_Filter_DisabledTooltip>Show disabled on/off settings only.</BWT_Settings_Filter_DisabledTooltip>
+    <BWT_Settings_Filter_Changed>Changed from default</BWT_Settings_Filter_Changed>
+    <BWT_Settings_Filter_ChangedTooltip>Show settings that differ from their default value.</BWT_Settings_Filter_ChangedTooltip>
+    <BWT_Settings_Filter_NotViewed>Not yet viewed</BWT_Settings_Filter_NotViewed>
+    <BWT_Settings_Filter_NotViewedTooltip>Show settings whose tooltip you have not opened.</BWT_Settings_Filter_NotViewedTooltip>
+    <BWT_Settings_Filter_Animations>Animations</BWT_Settings_Filter_Animations>
+    <BWT_Settings_Filter_AnimationsTooltip>Show animation and cursor movement settings.</BWT_Settings_Filter_AnimationsTooltip>
+    <BWT_Settings_Filter_SystemTooltip>Show settings under {0}.</BWT_Settings_Filter_SystemTooltip>
+    <BWT_Settings_Filter_VersionTooltip>Show settings added or changed in this Better Work Tab version.</BWT_Settings_Filter_VersionTooltip>
+    <BWT_Settings_Filter_Context>Context</BWT_Settings_Filter_Context>
+    <BWT_Settings_Preview_Work>Work</BWT_Settings_Preview_Work>
+    <BWT_Settings_Preview_Live>Live preview: {0}</BWT_Settings_Preview_Live>
+    <BWT_Settings_MasterHighlightColor_Applied>Applied the master color to all highlight settings.</BWT_Settings_MasterHighlightColor_Applied>
+    <BWT_Settings_DividerHeight_Reset>Reset all dividers to the default height.</BWT_Settings_DividerHeight_Reset>
+    <BWT_Settings_RestoreDefaults_Title>Restore defaults</BWT_Settings_RestoreDefaults_Title>
+    <BWT_Settings_RestoreDefaults_Confirm>Restore every Better Work Tab setting to its default? Your current settings will be lost.</BWT_Settings_RestoreDefaults_Confirm>
+    <BWT_Settings_RestoreDefaults_Done>Restored all default settings.</BWT_Settings_RestoreDefaults_Done>
+    <BWT_Settings_WorkloadMode_PreviewBlocked>Close the workload preview before changing workload mode.</BWT_Settings_WorkloadMode_PreviewBlocked>
+    <BWT_Settings_WorkloadMode_ChangeFailed>Better Work Tab could not change the workload mode.</BWT_Settings_WorkloadMode_ChangeFailed>
     
     <!-- Mod Compatibility -->
     <BWT_Settings_modcompat.header>Mod Compatibility</BWT_Settings_modcompat.header>
@@ -255,7 +369,7 @@
     <BWT_Settings_advanced.workloadsLegacy>Use legacy Workloads (1.0.5)</BWT_Settings_advanced.workloadsLegacy>
     <BWT_Settings_advanced.workloadsLegacy_Tooltip>Use the original Workloads behavior from Better Work Tab 1.0.5 instead of the modern Workloads implementation.</BWT_Settings_advanced.workloadsLegacy_Tooltip>
     <BWT_Settings_features.subWorkJobs>Specific jobs</BWT_Settings_features.subWorkJobs>
-    <BWT_Settings_features.subWorkJobs_Tooltip>Open a Work column to set priorities for its individual jobs. Use the shortcut below on a Work header or cell; use it again, or press Escape, to return.</BWT_Settings_features.subWorkJobs_Tooltip>
+    <BWT_Settings_features.subWorkJobs_Tooltip>Open a Work column to set priorities for its individual jobs. Use the shortcut below on a Work header or cell. Use it again, or press Escape, to return.</BWT_Settings_features.subWorkJobs_Tooltip>
     <BWT_Settings_subWorkJobs.openModifier>Shortcut modifier</BWT_Settings_subWorkJobs.openModifier>
     <BWT_Settings_subWorkJobs.openModifier_Tooltip>Modifier key used with the mouse button below to open or leave the specific-job view.</BWT_Settings_subWorkJobs.openModifier_Tooltip>
     <BWT_Settings_subWorkJobs.openButton>Shortcut mouse button</BWT_Settings_subWorkJobs.openButton>
@@ -311,11 +425,11 @@
     <BWT_Settings_ui.autoDisabledPriorityFixedValue>Fixed re-enabled priority</BWT_Settings_ui.autoDisabledPriorityFixedValue>
     <BWT_Settings_ui.autoDisabledPriorityFixedValue_Tooltip>Priority number used when the setting above is Fixed Priority.</BWT_Settings_ui.autoDisabledPriorityFixedValue_Tooltip>
     <BWT_Settings_ui.priorityColorPercentageGreen>Green priority threshold</BWT_Settings_ui.priorityColorPercentageGreen>
-    <BWT_Settings_ui.priorityColorPercentageGreen_Tooltip>For extended priorities, color the highest-priority number range green. Lower numbers are acted on first; this percentage is measured from priority 1 toward the maximum.</BWT_Settings_ui.priorityColorPercentageGreen_Tooltip>
+    <BWT_Settings_ui.priorityColorPercentageGreen_Tooltip>For extended priorities, color the highest-priority number range green. Lower numbers are acted on first. This percentage is measured from priority 1 toward the maximum.</BWT_Settings_ui.priorityColorPercentageGreen_Tooltip>
     <BWT_Settings_ui.priorityColorPercentageYellow>Yellow priority threshold</BWT_Settings_ui.priorityColorPercentageYellow>
     <BWT_Settings_ui.priorityColorPercentageYellow_Tooltip>For extended priorities, color priority numbers yellow through this cumulative percentage of the range. Lower numbers are acted on first.</BWT_Settings_ui.priorityColorPercentageYellow_Tooltip>
     <BWT_Settings_ui.priorityColorPercentageTan>Tan priority threshold</BWT_Settings_ui.priorityColorPercentageTan>
-    <BWT_Settings_ui.priorityColorPercentageTan_Tooltip>For extended priorities, color priority numbers tan through this cumulative percentage of the range. Lower numbers are acted on first; later numbers are gray.</BWT_Settings_ui.priorityColorPercentageTan_Tooltip>
+    <BWT_Settings_ui.priorityColorPercentageTan_Tooltip>For extended priorities, color priority numbers tan through this cumulative percentage of the range. Lower numbers are acted on first. Later numbers are gray.</BWT_Settings_ui.priorityColorPercentageTan_Tooltip>
     <BWT_Settings_features.multiplayer>Multiplayer Sync</BWT_Settings_features.multiplayer>
     <BWT_Settings_features.multiplayer_Tooltip>Enable multiplayer synchronization options.</BWT_Settings_features.multiplayer_Tooltip>
     <BWT_Settings_highlights.hover>Highlight on Hover</BWT_Settings_highlights.hover>
@@ -469,7 +583,7 @@
     <BWT_Settings_headers.underlineColor>Work-header underline color</BWT_Settings_headers.underlineColor>
     <BWT_Settings_headers.underlineColor_Tooltip>Colors the line beneath angled Work names and the stem used by vanilla-style Work headers.</BWT_Settings_headers.underlineColor_Tooltip>
     <BWT_Settings_headers.horizontalOffset>Horizontal offset</BWT_Settings_headers.horizontalOffset>
-    <BWT_Settings_headers.horizontalOffset_Tooltip>Adjust the horizontal position of angled headers. 0 is centered; 10 is the default. At -90°, the offset is automatically set to 0 for alignment.</BWT_Settings_headers.horizontalOffset_Tooltip>
+    <BWT_Settings_headers.horizontalOffset_Tooltip>Adjust the horizontal position of angled headers. 0 is centered, and 10 is the default. At -90°, the offset is automatically set to 0 for alignment.</BWT_Settings_headers.horizontalOffset_Tooltip>
     <BWT_Settings_compat.chronosPointer.header>Chronos Pointer integration (2 settings)</BWT_Settings_compat.chronosPointer.header>
     <BWT_Settings_compat.chronosPointer.header_Tooltip>Optional Work-tab time-bar integration for Chronos Pointer.</BWT_Settings_compat.chronosPointer.header_Tooltip>
     <BWT_Settings_ui.chronosPointerTimePriority>Chronos Pointer time bar</BWT_Settings_ui.chronosPointerTimePriority>
@@ -490,7 +604,7 @@
     <BWT_Settings_controls.fluffy.expand>Open or close specific jobs</BWT_Settings_controls.fluffy.expand>
     <BWT_Settings_controls.fluffy.expand_Tooltip>Fluffy&apos;s native Ctrl-header gesture is preserved. When BWT owns the tab, the configured specific-job shortcut routes through BWT and Expand beside opens Fluffy-style columns.</BWT_Settings_controls.fluffy.expand_Tooltip>
     <BWT_Settings_controls.fluffy.batch>Change a whole Work column</BWT_Settings_controls.fluffy.batch>
-    <BWT_Settings_controls.fluffy.batch_Tooltip>Shift-scroll changes all capable pawn priorities. Shift-click changes a whole specific-job column; on root Work headers, BWT&apos;s optional grouping action owns Shift-left-click.</BWT_Settings_controls.fluffy.batch_Tooltip>
+    <BWT_Settings_controls.fluffy.batch_Tooltip>Shift-scroll changes all capable pawn priorities. Shift-click changes a whole specific-job column. On root Work headers, BWT&apos;s optional grouping action uses Shift-left-click.</BWT_Settings_controls.fluffy.batch_Tooltip>
     <BWT_Settings_controls.fluffy.pawnRows>Adjust a pawn row</BWT_Settings_controls.fluffy.pawnRows>
     <BWT_Settings_controls.fluffy.pawnRows_Tooltip>Fluffy&apos;s Shift-click and Shift-wheel pawn-name gesture remains available when Fluffy owns the Work tab. BWT-owned layouts keep fixed aligned pawn-row heights.</BWT_Settings_controls.fluffy.pawnRows_Tooltip>
 </LanguageData>

--- a/Languages/English/Keyed/English.xml
+++ b/Languages/English/Keyed/English.xml
@@ -2,7 +2,7 @@
 <LanguageData>
 <BWTNotAssignedDoOnce>{0} Once</BWTNotAssignedDoOnce>
 <BWTNotAssignedAssignWork>Open {0} in Work tab</BWTNotAssignedAssignWork>
-<BWTManageWorkGivers>Open {0} sub-work ({1})</BWTManageWorkGivers>
+<BWTManageWorkGivers>Open specific jobs for {0} ({1})</BWTManageWorkGivers>
 <BWT_PriorityOneDoneFirstExtended>Priority 1 is done first.&#10;Priority {0} is done last.</BWT_PriorityOneDoneFirstExtended>
 
 <BWT_Enum_SubWorkTransitionStyle_ClassicGlideFlash>Classic glide</BWT_Enum_SubWorkTransitionStyle_ClassicGlideFlash>
@@ -11,9 +11,9 @@
 <BWT_Enum_SubWorkDrilldownStyle_FocusView>Focus view</BWT_Enum_SubWorkDrilldownStyle_FocusView>
 <BWT_Enum_SubWorkDrilldownStyle_ExpandBeside>Fluffy-style expansion</BWT_Enum_SubWorkDrilldownStyle_ExpandBeside>
 <BWT_SubWork_UseExpandedView>Expand beside</BWT_SubWork_UseExpandedView>
-<BWT_SubWork_UseExpandedView_Tooltip>Keep the main Work columns visible and expand this Work's specific jobs beside it. This enables BWT's optional expanded presentation.</BWT_SubWork_UseExpandedView_Tooltip>
+<BWT_SubWork_UseExpandedView_Tooltip>Keep the main Work columns visible and expand this Work type's specific jobs beside it.</BWT_SubWork_UseExpandedView_Tooltip>
 <BWT_SubWork_UseFocusedView>Focus view</BWT_SubWork_UseFocusedView>
-<BWT_SubWork_UseFocusedView_Tooltip>Return to Better Work Tab's focused full-tab specific-job view and turn off the expanded presentation.</BWT_SubWork_UseFocusedView_Tooltip>
+<BWT_SubWork_UseFocusedView_Tooltip>Show this Work type's specific jobs across the full tab.</BWT_SubWork_UseFocusedView_Tooltip>
 <BWT_SubWork_Chooser_FocusTitle>Better Work Tab focused view</BWT_SubWork_Chooser_FocusTitle>
 <BWT_SubWork_Chooser_FocusDescription>Replace Work columns with this Work's specific jobs.</BWT_SubWork_Chooser_FocusDescription>
 <BWT_SubWork_Chooser_ExpandTitle>Fluffy-style expansion</BWT_SubWork_Chooser_ExpandTitle>
@@ -52,7 +52,7 @@
 
 <BWT_RuleName>Rule Name</BWT_RuleName>
 <BWT_Priority>Priority</BWT_Priority>
-<BWT_Worktype>Target work type</BWT_Worktype>
+<BWT_Worktype>Target Work type</BWT_Worktype>
 <BWT_AllowOverwritingHigherPriority>Allow overwriting higher priority</BWT_AllowOverwritingHigherPriority>
 <BWT_HasHighestSkill>Pawn has highest skill</BWT_HasHighestSkill>
 <BWT_SkipIfAnotherPawnAssigned>Skip if another pawn assigned</BWT_SkipIfAnotherPawnAssigned>
@@ -62,11 +62,11 @@
 <BWT_HasChildOnMap>Has child on map</BWT_HasChildOnMap>
 <BWT_IsNaturalAlwaysAssign>Is vanilla always assign</BWT_IsNaturalAlwaysAssign>
 <BWT_RandomIfMultiple>Random if multiple</BWT_RandomIfMultiple>
-<BWT_IgnoreIfWorktypeNonexistent>Ignore missing work type</BWT_IgnoreIfWorktypeNonexistent>
+<BWT_IgnoreIfWorktypeNonexistent>Ignore missing Work type</BWT_IgnoreIfWorktypeNonexistent>
 <BWT_IsTopXSkill>Is top X skill</BWT_IsTopXSkill>
 <BWT_IsNthBestPawn>Is Nth best pawn</BWT_IsNthBestPawn>
 <BWT_IsNthBestSkill>Is Nth best skill</BWT_IsNthBestSkill>
-<BWT_LimitNumberOfWorktypes>Work type Limit</BWT_LimitNumberOfWorktypes>
+<BWT_LimitNumberOfWorktypes>Work type limit</BWT_LimitNumberOfWorktypes>
 <BWT_SkipIfPriorityForThisWorktypeAreadyAssigned>Skip if this priority is already assigned</BWT_SkipIfPriorityForThisWorktypeAreadyAssigned>
 <BWT_PassionLevel>Passion level</BWT_PassionLevel>
 <BWT_SkillLevelGreaterThan>Skill level more than</BWT_SkillLevelGreaterThan>
@@ -76,36 +76,36 @@
 <BWT_Gender>Assign if gender is</BWT_Gender>
 <BWT_Xenotype>Assign if xenotype is</BWT_Xenotype>
 <BWT_RequiredTrait>Required trait</BWT_RequiredTrait>
-<BWT_AssignSimilarWorktypes>Assign similar work types</BWT_AssignSimilarWorktypes>
+<BWT_AssignSimilarWorktypes>Assign similar Work types</BWT_AssignSimilarWorktypes>
 <BWT_FailedToApplyFallback>Fallback if no pawn matched</BWT_FailedToApplyFallback>
 
 <BWT_RuleName_Desc>A name to make it easier to tell what a rule does.</BWT_RuleName_Desc>
-<BWT_Priority_Desc>The priority to set the work type to. (Vanilla always assigns 3.)</BWT_Priority_Desc>
-<BWT_Worktype_Desc>If assigned, this will be the only work type this rule applies to.</BWT_Worktype_Desc>
+<BWT_Priority_Desc>Set this Work type to this priority. Vanilla's default is 3.</BWT_Priority_Desc>
+<BWT_Worktype_Desc>Limit this rule to one Work type.</BWT_Worktype_Desc>
 <BWT_AllowOverwritingHigherPriority_Desc>By default the highest priority is kept. This allows later rules to overwrite higher priority.</BWT_AllowOverwritingHigherPriority_Desc>
 <BWT_HasHighestSkill_Desc>Assign pawns tied for the highest relevant skill. Vanilla instead assigns one random starting pawn to each Work type.</BWT_HasHighestSkill_Desc>
 <BWT_SkipIfAnotherPawnAssigned_Desc>If another pawn is assigned, do not apply to the current pawn.</BWT_SkipIfAnotherPawnAssigned_Desc>
 <BWT_IsPregnant_Desc>Only apply if the pawn is pregnant.</BWT_IsPregnant_Desc>
 <BWT_IsCapableOfViolence_Desc>Only apply if the pawn is capable of violence.</BWT_IsCapableOfViolence_Desc>
-<BWT_AssignToPawnWithFewestWorkPriorities_Desc>Assign pawns with the fewest existing priorities; ties are included.</BWT_AssignToPawnWithFewestWorkPriorities_Desc>
+<BWT_AssignToPawnWithFewestWorkPriorities_Desc>Assign pawns with the fewest existing priorities. Ties are included.</BWT_AssignToPawnWithFewestWorkPriorities_Desc>
 <BWT_HasChildOnMap_Desc>Only apply if the pawn has a child of learning age on the map.</BWT_HasChildOnMap_Desc>
-<BWT_IsNaturalAlwaysAssign_Desc>Only assign if Vanilla tags the work type as an "always assign" work type. (Vanilla always assigns these.)</BWT_IsNaturalAlwaysAssign_Desc>
-<BWT_RandomIfMultiple_Desc>If multiple pawns were assigned the work type, choose one at random to assign.</BWT_RandomIfMultiple_Desc>
-<BWT_IgnoreIfWorktypeNonexistent_Desc>Only assign this work type if it exists. Used for modded work types.</BWT_IgnoreIfWorktypeNonexistent_Desc>
-<BWT_IsTopXSkill_Desc>Assign when this Work type is among the pawn's top X skills. Vanilla uses the top six.</BWT_IsTopXSkill_Desc>
-<BWT_IsNthBestPawn_Desc>Only assign if the pawn is Nth best at this work type. It must be exact.</BWT_IsNthBestPawn_Desc>
-<BWT_IsNthBestSkill_Desc>Only assign if the work type is this pawn's Nth best skill. It must be exact.</BWT_IsNthBestSkill_Desc>
-<BWT_LimitNumberOfWorktypes_Desc>Only assign if the pawn does not already have this many Work types assigned.</BWT_LimitNumberOfWorktypes_Desc>
-<BWT_SkipIfPriorityForThisWorktypeAreadyAssigned_Desc>Only assign if this priority has not already been assigned for this work type.</BWT_SkipIfPriorityForThisWorktypeAreadyAssigned_Desc>
-<BWT_PassionLevel_Desc>Only assign if the pawn's best relevant passion for the work type matches the selected passion.</BWT_PassionLevel_Desc>
-<BWT_SkillLevelGreaterThan_Desc>Only assign if the pawn's skill in the work type is greater than this number.</BWT_SkillLevelGreaterThan_Desc>
-<BWT_SkillLevelLessThan_Desc>Only assign if the pawn's skill in the work type is less than this number.</BWT_SkillLevelLessThan_Desc>
+<BWT_IsNaturalAlwaysAssign_Desc>Assign only if vanilla marks this Work type as always assigned.</BWT_IsNaturalAlwaysAssign_Desc>
+<BWT_RandomIfMultiple_Desc>When multiple colonists match this Work type, assign one at random.</BWT_RandomIfMultiple_Desc>
+<BWT_IgnoreIfWorktypeNonexistent_Desc>Skip this rule when the Work type is unavailable, such as when a mod is missing.</BWT_IgnoreIfWorktypeNonexistent_Desc>
+<BWT_IsTopXSkill_Desc>Assign when this Work type is among the colonist's top X skills. Vanilla uses the top six.</BWT_IsTopXSkill_Desc>
+<BWT_IsNthBestPawn_Desc>Assign only if the colonist ranks exactly Nth for this Work type.</BWT_IsNthBestPawn_Desc>
+<BWT_IsNthBestSkill_Desc>Assign only if this Work type is the colonist's Nth-best skill.</BWT_IsNthBestSkill_Desc>
+<BWT_LimitNumberOfWorktypes_Desc>Assign only if the colonist has fewer than this many assigned Work types.</BWT_LimitNumberOfWorktypes_Desc>
+<BWT_SkipIfPriorityForThisWorktypeAreadyAssigned_Desc>Assign only if this priority is not already set for this Work type.</BWT_SkipIfPriorityForThisWorktypeAreadyAssigned_Desc>
+<BWT_PassionLevel_Desc>Assign only if the colonist's relevant passion for this Work type matches the selected level.</BWT_PassionLevel_Desc>
+<BWT_SkillLevelGreaterThan_Desc>Assign only if the colonist's skill for this Work type is above this value.</BWT_SkillLevelGreaterThan_Desc>
+<BWT_SkillLevelLessThan_Desc>Assign only if the colonist's skill for this Work type is below this value.</BWT_SkillLevelLessThan_Desc>
 <BWT_MoveSpeedGreaterThan_Desc>Only assign if the pawn's move speed is greater than this number.</BWT_MoveSpeedGreaterThan_Desc>
 <BWT_MoveSpeedLessThan_Desc>Only assign if the pawn's move speed is less than this number.</BWT_MoveSpeedLessThan_Desc>
 <BWT_Gender_Desc>Only assign to pawns of this gender.</BWT_Gender_Desc>
 <BWT_Xenotype_Desc>Only assign to pawns with this xenotype.</BWT_Xenotype_Desc>
 <BWT_RequiredTrait_Desc>Only assign to pawns with this trait.</BWT_RequiredTrait_Desc>
-<BWT_AssignSimilarWorktypes_Desc>Also assign this rule to work types that use the same relevant skills.</BWT_AssignSimilarWorktypes_Desc>
+<BWT_AssignSimilarWorktypes_Desc>Also assign this rule to Work types that use the same relevant skills.</BWT_AssignSimilarWorktypes_Desc>
 <BWT_FailedToApplyFallback_Desc>Apply this rule if the primary rule did not assign any pawns.</BWT_FailedToApplyFallback_Desc>
 
 <BWT_BottomBar_RulesetTooltip>Ruleset: {0}\n\nClick to apply it to your colonists. Use ... to switch ruleset or open the rule builder.</BWT_BottomBar_RulesetTooltip>
@@ -116,27 +116,27 @@
 <BWT_BottomBar_WorkloadTooltipEmpty>No workload is saved yet.\n\nClick to save the current priorities as one.</BWT_BottomBar_WorkloadTooltipEmpty>
 <BWT_BottomBar_WorkloadMenuTooltip>Switch, rename, save or delete workloads.</BWT_BottomBar_WorkloadMenuTooltip>
 
-<BWT_RulesetBuilder_Title>Ruleset builder</BWT_RulesetBuilder_Title>
+<BWT_RulesetBuilder_Title>Rule Builder</BWT_RulesetBuilder_Title>
 <BWT_NoRuleset>No ruleset selected</BWT_NoRuleset>
 <BWT_ManageRulesets>Manage rulesets</BWT_ManageRulesets>
 <BWT_Back>Back</BWT_Back>
 <BWT_EditingRulesFor>Editing rules for {0}</BWT_EditingRulesFor>
 <BWT_AddNewRule>Add new rule</BWT_AddNewRule>
 <BWT_CannotModifyDefault>Default rulesets cannot be edited.</BWT_CannotModifyDefault>
-<BWT_NoRulesForWorkType>No rules for this work type yet.</BWT_NoRulesForWorkType>
+<BWT_NoRulesForWorkType>No rules for this Work type yet.</BWT_NoRulesForWorkType>
 <BWT_AssignPriority>Assign priority</BWT_AssignPriority>
 <BWT_Disabled>Disabled</BWT_Disabled>
 <BWT_PriorityLevel_Tooltip>Set priority to {0}.</BWT_PriorityLevel_Tooltip>
 <BWT_Conditions>Conditions</BWT_Conditions>
 <BWT_AddCondition>Add condition</BWT_AddCondition>
-<BWT_SelectWorkTypeFirst>Select a work type to edit rules.</BWT_SelectWorkTypeFirst>
+<BWT_SelectWorkTypeFirst>Select a Work type to edit its rules.</BWT_SelectWorkTypeFirst>
 <BWT_SelectOrCreateRule>Select a rule or create a new one.</BWT_SelectOrCreateRule>
 <BWT_Add_HasHighestSkill>Require highest skill</BWT_Add_HasHighestSkill>
 <BWT_Add_IsTopXSkill>Require top X skill</BWT_Add_IsTopXSkill>
 <BWT_Add_PassionLevel>Require passion level</BWT_Add_PassionLevel>
 <BWT_Add_SkillLevelGreaterThan>Skill level greater than</BWT_Add_SkillLevelGreaterThan>
 <BWT_Add_SkillLevelLessThan>Skill level less than</BWT_Add_SkillLevelLessThan>
-<BWT_Add_IsNaturalAlwaysAssign>Require always-active work type</BWT_Add_IsNaturalAlwaysAssign>
+<BWT_Add_IsNaturalAlwaysAssign>Require always-active Work type</BWT_Add_IsNaturalAlwaysAssign>
 <BWT_Add_RequiredTrait>Require trait</BWT_Add_RequiredTrait>
 <BWT_Add_Gender>Require gender</BWT_Add_Gender>
 <BWT_Add_Xenotype>Require xenotype</BWT_Add_Xenotype>
@@ -147,22 +147,22 @@
 <BWT_Add_AllowOverwritingHigherPriority>Allow overwriting higher priority</BWT_Add_AllowOverwritingHigherPriority>
 <BWT_NoConditionsAvailable>No additional conditions available.</BWT_NoConditionsAvailable>
 
-<BWT_WorkTypes>Work Types</BWT_WorkTypes>
-<BWT_SelectWorkType>Select Work Type</BWT_SelectWorkType>
+<BWT_WorkTypes>Work types</BWT_WorkTypes>
+<BWT_SelectWorkType>Select Work type</BWT_SelectWorkType>
 <BWT_Matches>Matches</BWT_Matches>
 <BWT_NoConditions>No conditions set. Click below to add.</BWT_NoConditions>
-<BWT_NewRuleset>New Ruleset</BWT_NewRuleset>
+<BWT_NewRuleset>New ruleset</BWT_NewRuleset>
 <BWT_Yes>Yes</BWT_Yes>
 <BWT_No>No</BWT_No>
 <BWT_None>None</BWT_None>
 <BWT_Minor>Minor</BWT_Minor>
 <BWT_Major>Major</BWT_Major>
-<BWT_Step1_Title>Select a work type</BWT_Step1_Title>
+<BWT_Step1_Title>Select a Work type</BWT_Step1_Title>
 <BWT_Step1_Subtitle>Pick a column to configure rules for.</BWT_Step1_Subtitle>
 <BWT_ShowOnlyConfigured>Show only configured ({0})</BWT_ShowOnlyConfigured>
-<BWT_ShowOnlyConfigured_Tooltip>Only show work types that already have rules configured.</BWT_ShowOnlyConfigured_Tooltip>
-<BWT_NoConfiguredWorkTypes>No work types have rules yet.</BWT_NoConfiguredWorkTypes>
-<BWT_NoMatchingWorkTypes>No work types match your search.</BWT_NoMatchingWorkTypes>
+<BWT_ShowOnlyConfigured_Tooltip>Show only Work types with configured rules.</BWT_ShowOnlyConfigured_Tooltip>
+<BWT_NoConfiguredWorkTypes>No Work types have rules yet.</BWT_NoConfiguredWorkTypes>
+<BWT_NoMatchingWorkTypes>No Work types match your search.</BWT_NoMatchingWorkTypes>
 
 <BWT_RelevantSkills>Relevant skills</BWT_RelevantSkills>
 <BWT_RulesConfigured>{0} rules configured</BWT_RulesConfigured>
@@ -179,12 +179,12 @@
 
 <!-- Unified Work-tab tutorial -->
 <BWT_Tutorial_Welcome_Title>Better Work Tab feature tour</BWT_Tutorial_Welcome_Title>
-<BWT_Tutorial_Welcome_Body>This tour assumes you already know RimWorld's Work tab and focuses only on what Better Work Tab adds or changes. You can pause at any time and return later.</BWT_Tutorial_Welcome_Body>
+<BWT_Tutorial_Welcome_Body>This tour covers what Better Work Tab adds to RimWorld's Work tab. Pause any time and return when you are ready.</BWT_Tutorial_Welcome_Body>
 <BWT_Tutorial_Welcome_WhatsNew>Explore 2.0 additions</BWT_Tutorial_Welcome_WhatsNew>
 <BWT_Tutorial_Welcome_Full>Explore all BWT features</BWT_Tutorial_Welcome_Full>
 <BWT_Tutorial_NotNow>Not now</BWT_Tutorial_NotNow>
 <BWT_Upgrade20_PromptTitle>Better Work Tab 2.0</BWT_Upgrade20_PromptTitle>
-<BWT_Upgrade20_PromptBody>Better Work Tab was updated to 2.0. Your settings are preserved, and new features remain disabled to keep existing behavior. Tour the new features?</BWT_Upgrade20_PromptBody>
+<BWT_Upgrade20_PromptBody>Better Work Tab is now 2.0. Your settings are unchanged, and new features start disabled. See what is new?</BWT_Upgrade20_PromptBody>
 <BWT_Upgrade20_StartTutorial>Show me the 2.0 tutorial</BWT_Upgrade20_StartTutorial>
 <BWT_Upgrade20_KeepSettings>Keep my existing settings</BWT_Upgrade20_KeepSettings>
 <BWT_FluffyMigration_Title>Fluffy Work Tab compatibility</BWT_FluffyMigration_Title>
@@ -197,10 +197,10 @@
 <BWT_FluffyMigration_SettingsContextTooltip>Settings for Fluffy-style controls, saved hourly priorities, visible compatibility columns, and choosing which mod owns the Work tab.</BWT_FluffyMigration_SettingsContextTooltip>
 <BWT_Tutorial_Selector_Title>Explore Better Work Tab</BWT_Tutorial_Selector_Title>
 <BWT_Tutorial_Selector_DefaultBody>Click a highlighted name, header, or priority to explore it.</BWT_Tutorial_Selector_DefaultBody>
-<BWT_Tutorial_Selector_AllDoneBody>That is everything you have switched on. There is more available.</BWT_Tutorial_Selector_AllDoneBody>
-<BWT_Tutorial_AlreadyUsing>You are already using this in your colony, so it is checked off. Open it anyway if you want the walkthrough.</BWT_Tutorial_AlreadyUsing>
+<BWT_Tutorial_Selector_AllDoneBody>You have explored every enabled feature. Turn on another feature to see its lesson.</BWT_Tutorial_Selector_AllDoneBody>
+<BWT_Tutorial_AlreadyUsing>Your colony already uses this feature. Open the lesson if you want a refresher.</BWT_Tutorial_AlreadyUsing>
 <BWT_Tutorial_Discover_Button>{0} switched off</BWT_Tutorial_Discover_Button>
-<BWT_Tutorial_Discover_Tooltip>{0} feature(s) are switched off in settings. Open them to see what they do.</BWT_Tutorial_Discover_Tooltip>
+<BWT_Tutorial_Discover_Tooltip>Features switched off: {0}. Open them to see what they do.</BWT_Tutorial_Discover_Tooltip>
 <BWT_Tutorial_Discover_Filter>Not switched on</BWT_Tutorial_Discover_Filter>
 <BWT_Tutorial_Discover_FilterTooltip>Better Work Tab features you have switched off. Turn one on and its walkthrough appears in the Work tab.</BWT_Tutorial_Discover_FilterTooltip>
 <BWT_Tutorial_SkipForNow>Skip for now</BWT_Tutorial_SkipForNow>
@@ -208,7 +208,7 @@
 <BWT_Tutorial_SkipLesson>Skip lesson</BWT_Tutorial_SkipLesson>
 
 <BWT_Tutorial_PawnHub_Title>Better Work Tab pawn tools</BWT_Tutorial_PawnHub_Title>
-<BWT_Tutorial_PawnHub_Body>Better Work Tab adds a pawn action menu for dividers, custom titles, and row colors. Select one of those additions below.</BWT_Tutorial_PawnHub_Body>
+<BWT_Tutorial_PawnHub_Body>Use the pawn action menu to add dividers, change titles, and set row colors. Choose a lesson below.</BWT_Tutorial_PawnHub_Body>
 <BWT_Tutorial_PawnMenu_Label>Open pawn actions</BWT_Tutorial_PawnMenu_Label>
 <BWT_Tutorial_PawnMenu_Title>Open pawn actions</BWT_Tutorial_PawnMenu_Title>
 <BWT_Tutorial_PawnMenu_Preview>Right-click a pawn name to open its Better Work Tab actions.</BWT_Tutorial_PawnMenu_Preview>
@@ -216,23 +216,23 @@
 <BWT_Tutorial_PawnMenu_Outcome>Menu open. These commands change the Work tab view only.</BWT_Tutorial_PawnMenu_Outcome>
 <BWT_Tutorial_PawnDivider_Label>Add a divider</BWT_Tutorial_PawnDivider_Label>
 <BWT_Tutorial_PawnDivider_Title>Organize pawns with dividers</BWT_Tutorial_PawnDivider_Title>
-<BWT_Tutorial_PawnDivider_Preview>Dividers label, separate, collapse, and visually organize groups of pawn rows.</BWT_Tutorial_PawnDivider_Preview>
+<BWT_Tutorial_PawnDivider_Preview>Dividers label groups of colonists and let you collapse their rows.</BWT_Tutorial_PawnDivider_Preview>
 <BWT_Tutorial_PawnDivider_Action>Right-click the highlighted pawn.</BWT_Tutorial_PawnDivider_Action>
-<BWT_Tutorial_PawnDivider_ActionChoose>Select “Insert divider above.”</BWT_Tutorial_PawnDivider_ActionChoose>
-<BWT_Tutorial_PawnDivider_Outcome>Divider added. Group and collapse rows to stay readable.</BWT_Tutorial_PawnDivider_Outcome>
+<BWT_Tutorial_PawnDivider_ActionChoose>Select 'Insert divider above.'</BWT_Tutorial_PawnDivider_ActionChoose>
+<BWT_Tutorial_PawnDivider_Outcome>Divider added. You can now group and collapse these rows.</BWT_Tutorial_PawnDivider_Outcome>
 <BWT_Tutorial_PawnAppearance_Label>Customize pawn row</BWT_Tutorial_PawnAppearance_Label>
 <BWT_Tutorial_PawnAppearance_Title>Change title or color</BWT_Tutorial_PawnAppearance_Title>
 <BWT_Tutorial_PawnAppearance_Preview>The pawn menu can change the displayed title and row background color.</BWT_Tutorial_PawnAppearance_Preview>
 <BWT_Tutorial_PawnAppearance_Action>Right-click the highlighted pawn.</BWT_Tutorial_PawnAppearance_Action>
-<BWT_Tutorial_PawnAppearance_ActionChoose>Select “Set background color...” or “Change title...”.</BWT_Tutorial_PawnAppearance_ActionChoose>
-<BWT_Tutorial_PawnAppearance_ActionChooseColorOnly>Select “Set background color...”.</BWT_Tutorial_PawnAppearance_ActionChooseColorOnly>
+<BWT_Tutorial_PawnAppearance_ActionChoose>Select 'Set background color...' or 'Change title...'.</BWT_Tutorial_PawnAppearance_ActionChoose>
+<BWT_Tutorial_PawnAppearance_ActionChooseColorOnly>Select 'Set background color...'.</BWT_Tutorial_PawnAppearance_ActionChooseColorOnly>
 <BWT_Tutorial_PawnAppearance_ActionColor>Pick a color for this row.</BWT_Tutorial_PawnAppearance_ActionColor>
 <BWT_Tutorial_PawnAppearance_ActionType>Type a different display title in the highlighted field.</BWT_Tutorial_PawnAppearance_ActionType>
 <BWT_Tutorial_PawnAppearance_ActionConfirm>Click OK.</BWT_Tutorial_PawnAppearance_ActionConfirm>
 <BWT_Tutorial_PawnAppearance_Outcome>Row updated. Display only, the colonist is unchanged.</BWT_Tutorial_PawnAppearance_Outcome>
 
 <BWT_Tutorial_HeaderHub_Title>Better Work Tab header tools</BWT_Tutorial_HeaderHub_Title>
-<BWT_Tutorial_HeaderHub_Body>Better Work Tab makes headers interactive: reorder execution, move selected groups, or open specific jobs.</BWT_Tutorial_HeaderHub_Body>
+<BWT_Tutorial_HeaderHub_Body>Use headers to reorder Work types, move selected groups, and open specific jobs.</BWT_Tutorial_HeaderHub_Body>
 <BWT_Tutorial_HeaderReorder_Label>Reorder work columns</BWT_Tutorial_HeaderReorder_Label>
 <BWT_Tutorial_HeaderReorder_Title>Reorder work columns</BWT_Tutorial_HeaderReorder_Title>
 <BWT_Tutorial_HeaderReorder_Preview>Drag a Work header to reorder execution. When priorities match, work runs from left to right.</BWT_Tutorial_HeaderReorder_Preview>
@@ -247,7 +247,7 @@
 <BWT_Tutorial_HeaderGroup_Outcome>Header selected. Drag any selected header to move the group.</BWT_Tutorial_HeaderGroup_Outcome>
 <BWT_Tutorial_HeaderSubWork_Label>Open specific jobs</BWT_Tutorial_HeaderSubWork_Label>
 <BWT_Tutorial_HeaderSubWork_Title>Open specific jobs</BWT_Tutorial_HeaderSubWork_Title>
-<BWT_Tutorial_HeaderSubWork_Preview>Specific jobs can focus or expand the grid, with priorities, overrides, reordering, and reassignment.</BWT_Tutorial_HeaderSubWork_Preview>
+<BWT_Tutorial_HeaderSubWork_Preview>Open specific jobs to set priorities, overrides, order, and reassignment for each job.</BWT_Tutorial_HeaderSubWork_Preview>
 <BWT_Tutorial_HeaderSubWork_ActionShortcut>{0} the highlighted Work header to open its specific jobs.</BWT_Tutorial_HeaderSubWork_ActionShortcut>
 <BWT_Tutorial_HeaderSubWork_Outcome>Specific jobs open. Escape or {0} returns.</BWT_Tutorial_HeaderSubWork_Outcome>
 <BWT_Tutorial_Gesture_LeftClick>LEFT CLICK</BWT_Tutorial_Gesture_LeftClick>
@@ -268,50 +268,200 @@
 <BWT_Tutorial_Gesture_Complete>Finish the lesson</BWT_Tutorial_Gesture_Complete>
 
 <BWT_Tutorial_PriorityHub_Title>Better Work Tab priority tools</BWT_Tutorial_PriorityHub_Title>
-<BWT_Tutorial_PriorityHub_Body>Better Work Tab extends these cells with skill-number views, daily schedules, and a configurable priority range.</BWT_Tutorial_PriorityHub_Body>
-<BWT_Tutorial_PriorityHub_ShiftBody>Better Work Tab is showing the pawn's skill number while Shift is held. Choose “View skill number” for guidance on this added view.</BWT_Tutorial_PriorityHub_ShiftBody>
+<BWT_Tutorial_PriorityHub_Body>Priority cells can show skill numbers, set hourly priorities, and use a wider priority range.</BWT_Tutorial_PriorityHub_Body>
+<BWT_Tutorial_PriorityHub_ShiftBody>Better Work Tab is showing the pawn's skill number while Shift is held. Choose 'View skill number' for guidance on this view.</BWT_Tutorial_PriorityHub_ShiftBody>
 <BWT_Tutorial_HeaderHub_SubWorkBody>Better Work Tab is showing this Work category's specific jobs. Repeat the shortcut or press Escape to return to the category view.</BWT_Tutorial_HeaderHub_SubWorkBody>
 <BWT_Tutorial_PrioritySkill_Label>View skill number</BWT_Tutorial_PrioritySkill_Label>
 <BWT_Tutorial_PrioritySkill_Title>View skill number</BWT_Tutorial_PrioritySkill_Title>
 <BWT_Tutorial_PrioritySkill_Preview>Hold Shift to display the pawn's skill number for that work.</BWT_Tutorial_PrioritySkill_Preview>
 <BWT_Tutorial_PrioritySkill_Action>Hold Shift.</BWT_Tutorial_PrioritySkill_Action>
-<BWT_Tutorial_PrioritySkill_Held>The Work grid is showing each pawn's relevant skill number instead of their priority while Shift is held. Higher skill numbers help you compare who is naturally better at that Work. Keep holding Shift while you look; release it when you are ready to return to priorities.</BWT_Tutorial_PrioritySkill_Held>
+<BWT_Tutorial_PrioritySkill_Held>The Work grid is showing each pawn's relevant skill number instead of their priority while Shift is held. Higher skill numbers help you compare who is naturally better at that Work. Keep holding Shift while you look. Release it when you are ready to return to priorities.</BWT_Tutorial_PrioritySkill_Held>
 <BWT_Tutorial_PrioritySkill_SecondaryVisible>Your current skill-number settings can also show a smaller secondary skill number in the cell corner.</BWT_Tutorial_PrioritySkill_SecondaryVisible>
 <BWT_Tutorial_PrioritySkill_Outcome>Shift shows skill numbers. Priorities were not changed.</BWT_Tutorial_PrioritySkill_Outcome>
 <BWT_Tutorial_PrioritySchedule_Label>Open time schedules</BWT_Tutorial_PrioritySchedule_Label>
 <BWT_Tutorial_PrioritySchedule_Title>Open time schedules</BWT_Tutorial_PrioritySchedule_Title>
-<BWT_Tutorial_PrioritySchedule_Preview>Ctrl-click a priority cell to create a daily schedule with a different priority for each hour.</BWT_Tutorial_PrioritySchedule_Preview>
+<BWT_Tutorial_PrioritySchedule_Preview>Ctrl-click a priority cell to set hourly priorities for that Work type.</BWT_Tutorial_PrioritySchedule_Preview>
 <BWT_Tutorial_PrioritySchedule_ActionOpen>Ctrl-click the highlighted priority cell to open its hourly schedule.</BWT_Tutorial_PrioritySchedule_ActionOpen>
 <BWT_Tutorial_PrioritySchedule_ActionEdit>Change any hour cell: click, right-click, or scroll.</BWT_Tutorial_PrioritySchedule_ActionEdit>
 <BWT_Tutorial_PrioritySchedule_ActionClose>Ctrl-click an hour cell to close the schedule.</BWT_Tutorial_PrioritySchedule_ActionClose>
 <BWT_Tutorial_PrioritySchedule_Outcome>Schedule saved. Ctrl-click the cell to edit all 24 hours.</BWT_Tutorial_PrioritySchedule_Outcome>
 <BWT_Tutorial_PriorityRange_Label>Set priority range</BWT_Tutorial_PriorityRange_Label>
 <BWT_Tutorial_PriorityRange_Title>Set priority range</BWT_Tutorial_PriorityRange_Title>
-<BWT_Tutorial_PriorityRange_Preview>Open the priority provider or maximum setting. Better Work Tab defaults to 1–9, supports 99, and preserves compatible providers.</BWT_Tutorial_PriorityRange_Preview>
+<BWT_Tutorial_PriorityRange_Preview>Open the priority source or maximum setting. Better Work Tab defaults to 1-9, supports 99, and works with compatible priority mods.</BWT_Tutorial_PriorityRange_Preview>
 <BWT_Tutorial_PriorityRange_Filter>Priority range</BWT_Tutorial_PriorityRange_Filter>
-<BWT_Tutorial_PriorityRange_FilterTooltip>Priority provider and maximum-priority settings for the Work tab.</BWT_Tutorial_PriorityRange_FilterTooltip>
+<BWT_Tutorial_PriorityRange_FilterTooltip>Priority source and maximum-priority settings for the Work tab.</BWT_Tutorial_PriorityRange_FilterTooltip>
 <BWT_Tutorial_PriorityRange_Action>Drag the slider to the highest priority number you want.</BWT_Tutorial_PriorityRange_Action>
 <BWT_Tutorial_PriorityRange_Outcome>Priority range set. A wider range gives finer control.</BWT_Tutorial_PriorityRange_Outcome>
 <BWT_Tutorial_Unknown_Action>Return to the tutorial map and select an available lesson.</BWT_Tutorial_Unknown_Action>
 
 <BWT_Tutorial_RuleBuilder2_Label>Try Rule Builder 2.0</BWT_Tutorial_RuleBuilder2_Label>
 <BWT_Tutorial_RuleBuilder2_Title>Rule Builder 2.0</BWT_Tutorial_RuleBuilder2_Title>
-<BWT_Tutorial_RuleBuilder2_Preview>The rewritten builder uses focused cards, a live match preview, and an explicit application system.</BWT_Tutorial_RuleBuilder2_Preview>
-<BWT_Tutorial_RuleBuilder2_Action>Build the rule, check the preview, then apply it.</BWT_Tutorial_RuleBuilder2_Action>
-<BWT_Tutorial_RuleBuilder2_Outcome>Rule ready. Preview never changes priorities, Apply does.</BWT_Tutorial_RuleBuilder2_Outcome>
+<BWT_Tutorial_RuleBuilder2_Preview>Rule Builder 2.0 guides you through choosing a target, conditions, and an action. Check the matching colonists before you apply it.</BWT_Tutorial_RuleBuilder2_Preview>
+<BWT_Tutorial_RuleBuilder2_Action>Choose a target, add conditions, set an action, then check the map.</BWT_Tutorial_RuleBuilder2_Action>
+<BWT_Tutorial_RuleBuilder2_Outcome>Your rule is ready. Map check does not change priorities. Apply does.</BWT_Tutorial_RuleBuilder2_Outcome>
 
 <BWT_Tutorial_FluffyCoexistence_Label>Test full Fluffy coexistence</BWT_Tutorial_FluffyCoexistence_Label>
 <BWT_Tutorial_FluffyCoexistence_Title>Better Work Tab and Fluffy remain active</BWT_Tutorial_FluffyCoexistence_Title>
 <BWT_Tutorial_FluffyCoexistence_Preview>Switch to Fluffy's complete Work interface and back while preserving Better Work Tab state.</BWT_Tutorial_FluffyCoexistence_Preview>
 <BWT_Tutorial_FluffyCoexistence_Action>Switch the Work-tab owner, then come back here.</BWT_Tutorial_FluffyCoexistence_Action>
-<BWT_Tutorial_FluffyCoexistence_ActionSwitch>Both mods remain active; this changes only the visible Work interface. Switch to Fluffy now. This lesson window will stay open.</BWT_Tutorial_FluffyCoexistence_ActionSwitch>
+<BWT_Tutorial_FluffyCoexistence_ActionSwitch>Both mods remain active. This changes only the visible Work interface. Switch to Fluffy now. This lesson window will stay open.</BWT_Tutorial_FluffyCoexistence_ActionSwitch>
 <BWT_Tutorial_FluffyCoexistence_ActionReturn>Fluffy now owns the Work interface, while Better Work Tab remains active. Return to verify its settings and column state.</BWT_Tutorial_FluffyCoexistence_ActionReturn>
-<BWT_Tutorial_FluffyCoexistence_ActionPreserved>You returned to Better Work Tab. Its specific-job presentation and stored column order were preserved while Fluffy owned the interface.</BWT_Tutorial_FluffyCoexistence_ActionPreserved>
-<BWT_Tutorial_FluffyCoexistence_ActionChanged>You returned to Better Work Tab, but its stored presentation or column order changed. Review the lesson details before continuing.</BWT_Tutorial_FluffyCoexistence_ActionChanged>
+<BWT_Tutorial_FluffyCoexistence_ActionPreserved>You returned to Better Work Tab. It kept the specific-job layout and column order used before you switched to Fluffy.</BWT_Tutorial_FluffyCoexistence_ActionPreserved>
+<BWT_Tutorial_FluffyCoexistence_ActionChanged>You returned to Better Work Tab, but its specific-job layout or column order changed. Review the lesson details before continuing.</BWT_Tutorial_FluffyCoexistence_ActionChanged>
 <BWT_Tutorial_FluffyCoexistence_Outcome>Switched back. Better Work Tab kept your columns and jobs.</BWT_Tutorial_FluffyCoexistence_Outcome>
 <BWT_Tutorial_FluffySwitch>Switch to Fluffy's interface</BWT_Tutorial_FluffySwitch>
 <BWT_Tutorial_BWTReturn>Return to Better Work Tab</BWT_Tutorial_BWTReturn>
 <BWT_Tutorial_FinishLesson>Finish lesson</BWT_Tutorial_FinishLesson>
+
+<!-- Work-tab controls -->
+<BWT_Header_ManualPriorities>Manual priorities</BWT_Header_ManualPriorities>
+<BWT_Header_SimplePriorities>Simple priorities</BWT_Header_SimplePriorities>
+<BWT_Header_OpenHourlyPriorities>Open hourly priorities</BWT_Header_OpenHourlyPriorities>
+<BWT_Header_CloseHourlyPriorities>Close hourly priorities</BWT_Header_CloseHourlyPriorities>
+<BWT_Header_ExpandSpecificJobs>Expand all specific jobs</BWT_Header_ExpandSpecificJobs>
+<BWT_Header_CollapseSpecificJobs>Collapse all specific jobs</BWT_Header_CollapseSpecificJobs>
+<BWT_Divider_ExpandSection>Expand section</BWT_Divider_ExpandSection>
+<BWT_Divider_CollapseSection>Collapse section</BWT_Divider_CollapseSection>
+<BWT_SpecificJob_DragToReorder>Drag to reorder</BWT_SpecificJob_DragToReorder>
+<BWT_SpecificJob_DragToMove>Hold and drag to reorder. Drag onto another Work header to move this specific job.</BWT_SpecificJob_DragToMove>
+<BWT_SpecificJob_BackToWorkTypes>Back to Work types. You can also press Escape.</BWT_SpecificJob_BackToWorkTypes>
+<BWT_SpecificJob_PawnsWithOverrides>Pawns with overrides: {0}</BWT_SpecificJob_PawnsWithOverrides>
+<BWT_SpecificJob_ParentDisabledOverride>The parent Work type is disabled. Click the priority box to enable it. Click the gold ring to use the shared specific-job priority again.</BWT_SpecificJob_ParentDisabledOverride>
+
+<!-- Hourly priorities -->
+<BWT_HourlyPriorities_DividerName>{0} hourly priorities</BWT_HourlyPriorities_DividerName>
+<BWT_HourlyPriorities_SelectWholeDay>Select the whole day</BWT_HourlyPriorities_SelectWholeDay>
+<BWT_HourlyPriorities_SelectCurrentHour>Select the current hour</BWT_HourlyPriorities_SelectCurrentHour>
+<BWT_HourlyPriorities_OpenForWorkType>Open hourly priorities for {0}</BWT_HourlyPriorities_OpenForWorkType>
+<BWT_HourlyPriorities_ClearRejected>Could not clear the hourly priorities.</BWT_HourlyPriorities_ClearRejected>
+<BWT_HourlyPriorities_WriteRejected>Could not save the hourly priorities.</BWT_HourlyPriorities_WriteRejected>
+<BWT_HourlyPriorities_CopyUnavailable>Better Work Tab cannot copy hourly priorities while another mod controls priority data.</BWT_HourlyPriorities_CopyUnavailable>
+<BWT_HourlyPriorities_Copied>Copied hourly priorities for {0}.</BWT_HourlyPriorities_Copied>
+<BWT_HourlyPriorities_PasteUnavailable>Better Work Tab cannot paste hourly priorities while another mod controls priority data.</BWT_HourlyPriorities_PasteUnavailable>
+<BWT_HourlyPriorities_PasteRejected>Could not paste the hourly priorities.</BWT_HourlyPriorities_PasteRejected>
+<BWT_HourlyPriorities_Pasted>Pasted hourly priorities from {0}.</BWT_HourlyPriorities_Pasted>
+<BWT_HourlyPriorities_OpenUnavailable>Better Work Tab cannot open hourly priorities while another mod controls priority data.</BWT_HourlyPriorities_OpenUnavailable>
+<BWT_HourlyPriorities_HourTooltip>Hour {0}. Priority {1}.</BWT_HourlyPriorities_HourTooltip>
+<BWT_Priority_ReadOnlyExternal>Another mod controls priority data, so Better Work Tab cannot change this priority.</BWT_Priority_ReadOnlyExternal>
+
+<!-- Workloads -->
+<BWT_Workload_OpenPreviewTooltip>Preview the saved priorities in {0} without changing your colony.</BWT_Workload_OpenPreviewTooltip>
+<BWT_Workload_PreviewUnavailable>Workload previews are unavailable.</BWT_Workload_PreviewUnavailable>
+<BWT_Workload_SelectBeforePreview>Choose a workload from the ... menu before opening a preview.</BWT_Workload_SelectBeforePreview>
+<BWT_Workload_SaveAs>Save as</BWT_Workload_SaveAs>
+<BWT_Workload_SaveAsTooltip>Save these changes as a new workload. Your colony will not change until you press Apply.</BWT_Workload_SaveAsTooltip>
+<BWT_Workload_Save>Save</BWT_Workload_Save>
+<BWT_Workload_SaveTooltip>Save these changes to this workload. Your colony will not change until you press Apply.</BWT_Workload_SaveTooltip>
+<BWT_Workload_Cancel>Cancel</BWT_Workload_Cancel>
+<BWT_Workload_CancelTooltip>Close the preview without changing your colony.</BWT_Workload_CancelTooltip>
+<BWT_Workload_Apply>Apply</BWT_Workload_Apply>
+<BWT_Workload_NoSaved>No saved workloads.</BWT_Workload_NoSaved>
+<BWT_Workload_New>New workload</BWT_Workload_New>
+<BWT_Workload_Actions>Workload actions</BWT_Workload_Actions>
+<BWT_Workload_Rename>Rename</BWT_Workload_Rename>
+<BWT_Workload_Delete>Delete</BWT_Workload_Delete>
+<BWT_Workload_SaveAsTitle>Save workload as</BWT_Workload_SaveAsTitle>
+<BWT_Workload_NewTitle>New workload</BWT_Workload_NewTitle>
+<BWT_Workload_RenameTitle>Rename workload</BWT_Workload_RenameTitle>
+<BWT_Workload_ApplyLegacyTitle>Apply legacy workload?</BWT_Workload_ApplyLegacyTitle>
+<BWT_Workload_ApplyLegacyBody>This replaces every current Work priority with the saved values. Continue?</BWT_Workload_ApplyLegacyBody>
+<BWT_Workload_DefaultName>Workload {0}</BWT_Workload_DefaultName>
+<BWT_Workload_CopyName>{0} copy</BWT_Workload_CopyName>
+<BWT_Workload_NameRequired>Enter a workload name.</BWT_Workload_NameRequired>
+<BWT_Workload_PreviewEnded>This workload preview is no longer open.</BWT_Workload_PreviewEnded>
+<BWT_Workload_OperationFailed>Better Work Tab could not finish that workload action.</BWT_Workload_OperationFailed>
+<BWT_Workload_FinishBeforeOpeningList>Finish or cancel the current workload preview before opening the workload list.</BWT_Workload_FinishBeforeOpeningList>
+<BWT_Workload_NoCurrentGame>Load or start a game before using workloads.</BWT_Workload_NoCurrentGame>
+<BWT_Workload_NotReady>Workloads are not ready yet.</BWT_Workload_NotReady>
+<BWT_Workload_PreviewLegacyUnavailable>Workload previews are unavailable while legacy workloads are enabled.</BWT_Workload_PreviewLegacyUnavailable>
+<BWT_Workload_Empty>This workload does not contain any saved settings.</BWT_Workload_Empty>
+<BWT_Workload_CaptureFailed>Better Work Tab could not read all current Work-tab settings.</BWT_Workload_CaptureFailed>
+<BWT_Workload_ModeUnavailable>That workload mode is unavailable.</BWT_Workload_ModeUnavailable>
+<BWT_Workload_CloseBeforeModeChange>Close the workload preview before changing workload mode.</BWT_Workload_CloseBeforeModeChange>
+<BWT_Workload_UnsupportedData>This workload contains data from an older or unsupported format. Apply and save are disabled to avoid losing it.</BWT_Workload_UnsupportedData>
+<BWT_Workload_UnsupportedDataShort>older or unsupported data</BWT_Workload_UnsupportedDataShort>
+<BWT_Workload_PreviewRefreshFailed>The workload was saved, but Better Work Tab could not refresh the preview. Cancel it before trying again.</BWT_Workload_PreviewRefreshFailed>
+<BWT_Workload_MultiplayerRecovery>Multiplayer is still finishing the previous workload action. You cannot edit this preview yet.</BWT_Workload_MultiplayerRecovery>
+<BWT_Workload_MultiplayerWaiting>Waiting for multiplayer to finish the workload {0}.</BWT_Workload_MultiplayerWaiting>
+<BWT_Workload_StatusRecovery> • finishing</BWT_Workload_StatusRecovery>
+<BWT_Workload_StatusSyncing> • syncing</BWT_Workload_StatusSyncing>
+<BWT_Workload_StatusPreview> • preview</BWT_Workload_StatusPreview>
+<BWT_Workload_ApplyAction>apply</BWT_Workload_ApplyAction>
+<BWT_Workload_SaveAction>save</BWT_Workload_SaveAction>
+<BWT_Workload_SaveAsAction>save as</BWT_Workload_SaveAsAction>
+<BWT_Workload_OperationAction>action</BWT_Workload_OperationAction>
+<BWT_Workload_MultiplayerNotSaved>Multiplayer could not finish the workload {0}. The preview is still open. {1}</BWT_Workload_MultiplayerNotSaved>
+<BWT_Workload_NoChangesMade>No workload settings changed.</BWT_Workload_NoChangesMade>
+<BWT_Workload_MultiplayerSaved>Multiplayer finished the workload {0}. The preview remains open.</BWT_Workload_MultiplayerSaved>
+<BWT_Workload_MultiplayerApplyCloseFailed>Multiplayer applied the workload, but Better Work Tab could not close the preview.</BWT_Workload_MultiplayerApplyCloseFailed>
+<BWT_Workload_MultiplayerConfirmed>Multiplayer finished the workload action.</BWT_Workload_MultiplayerConfirmed>
+<BWT_Workload_SettingsStatus>A workload preview is open. Alt-click still opens the related settings.</BWT_Workload_SettingsStatus>
+<BWT_Workload_PrioritySourceBWT>Priority source: Better Work Tab</BWT_Workload_PrioritySourceBWT>
+<BWT_Workload_PrioritySourceExternal>Priority source: {0}</BWT_Workload_PrioritySourceExternal>
+<BWT_Workload_UnsupportedOlderClears>older reset instructions</BWT_Workload_UnsupportedOlderClears>
+<BWT_Workload_UnsupportedOlderSchedules>older hourly priorities</BWT_Workload_UnsupportedOlderSchedules>
+<BWT_Workload_UnsupportedOlderDisplay>older display settings</BWT_Workload_UnsupportedOlderDisplay>
+<BWT_Workload_UnsupportedList>Unsupported workload data: {0}</BWT_Workload_UnsupportedList>
+<BWT_Workload_ValidationFailed>Cannot apply this workload because some saved data is invalid.</BWT_Workload_ValidationFailed>
+<BWT_Workload_ValidationDetails>Cannot apply this workload: {0}</BWT_Workload_ValidationDetails>
+<BWT_Workload_GameChanged>The game changed before the multiplayer workload finished. Try again.</BWT_Workload_GameChanged>
+<BWT_Workload_FinishPreviewBefore>Finish or cancel the workload preview before {0}.</BWT_Workload_FinishPreviewBefore>
+<BWT_Workload_ChangingWorkloads>changing workloads</BWT_Workload_ChangingWorkloads>
+<BWT_Workload_NotFound>Better Work Tab could not find that workload.</BWT_Workload_NotFound>
+<BWT_Workload_Selected>Workload selected.</BWT_Workload_Selected>
+<BWT_Workload_Creating>creating another workload</BWT_Workload_Creating>
+<BWT_Workload_Created>Created workload {0}.</BWT_Workload_Created>
+<BWT_Workload_Renaming>renaming this workload</BWT_Workload_Renaming>
+<BWT_Workload_Renamed>Workload renamed.</BWT_Workload_Renamed>
+<BWT_Workload_Deleting>deleting this workload</BWT_Workload_Deleting>
+<BWT_Workload_Deleted>Workload deleted.</BWT_Workload_Deleted>
+<BWT_Workload_NoActivePreview>No workload preview is open.</BWT_Workload_NoActivePreview>
+<BWT_Workload_MultiplayerStartFailed>Better Work Tab could not start the multiplayer workload action.</BWT_Workload_MultiplayerStartFailed>
+<BWT_Workload_PreviewCanceled>Preview canceled. Your colony was not changed.</BWT_Workload_PreviewCanceled>
+<BWT_Workload_NothingToSave>Nothing has changed, so there is nothing to save.</BWT_Workload_NothingToSave>
+<BWT_Workload_NoActivePreviewForSaveAs>Open a workload preview before saving it as a new workload.</BWT_Workload_NoActivePreviewForSaveAs>
+<BWT_Workload_Switching>switching workloads</BWT_Workload_Switching>
+<BWT_Workload_FinishBeforeSwitching>Finish or cancel the current workload preview before switching workloads. Save first if you want to keep your changes.</BWT_Workload_FinishBeforeSwitching>
+<BWT_Workload_SpecificJobMissing>That specific job is no longer available.</BWT_Workload_SpecificJobMissing>
+<BWT_Workload_SpecificJobPriorityUnavailable>This workload does not store specific-job priorities.</BWT_Workload_SpecificJobPriorityUnavailable>
+<BWT_Workload_SpecificJobChangeFailed>Better Work Tab could not change that specific job in the preview.</BWT_Workload_SpecificJobChangeFailed>
+<BWT_Workload_SpecificJobOrderTargetMissing>Better Work Tab could not find that specific job in the preview.</BWT_Workload_SpecificJobOrderTargetMissing>
+<BWT_Workload_SpecificJobOrderUnavailable>This workload does not store specific-job order.</BWT_Workload_SpecificJobOrderUnavailable>
+<BWT_Workload_SpecificJobOrderChangeFailed>Better Work Tab could not reorder the specific jobs in the preview.</BWT_Workload_SpecificJobOrderChangeFailed>
+<BWT_Workload_HourlyPriorityMissing>Those hourly priorities are no longer available.</BWT_Workload_HourlyPriorityMissing>
+<BWT_Workload_HourlyPriorityUnavailable>This workload does not store hourly priorities.</BWT_Workload_HourlyPriorityUnavailable>
+<BWT_Workload_HourlyPriorityChangeFailed>Better Work Tab could not change the hourly priorities in the preview.</BWT_Workload_HourlyPriorityChangeFailed>
+<BWT_Workload_PawnCannotChange>This colonist cannot be changed in the current preview.</BWT_Workload_PawnCannotChange>
+<BWT_Workload_PawnMissing>This colonist is no longer available.</BWT_Workload_PawnMissing>
+<BWT_Workload_PawnNeverIncluded>This workload never included that colonist.</BWT_Workload_PawnNeverIncluded>
+<BWT_Workload_PawnIncluded>Colonist included when you apply this workload.</BWT_Workload_PawnIncluded>
+<BWT_Workload_PawnIncludedCurrent>Colonist included with their current Work settings.</BWT_Workload_PawnIncludedCurrent>
+<BWT_Workload_PawnExcluded>Colonist excluded. Their current Work settings will not change.</BWT_Workload_PawnExcluded>
+<BWT_Workload_PawnOutside>This workload does not include that colonist, so their Work settings will not change.</BWT_Workload_PawnOutside>
+<BWT_Workload_PawnNoStoredSettings>This workload does not store any settings that can be copied for this colonist.</BWT_Workload_PawnNoStoredSettings>
+<BWT_Workload_PreviewOpened>Preview open. Your colony will not change until you press Apply.</BWT_Workload_PreviewOpened>
+<BWT_Workload_PawnIncludedTooltip>This colonist is included in the workload preview.</BWT_Workload_PawnIncludedTooltip>
+<BWT_Workload_PawnNewTooltip>This colonist was not in the saved workload. Right-click the row to include them.</BWT_Workload_PawnNewTooltip>
+<BWT_Workload_PawnOutsideTooltip>This workload does not include this colonist. Apply will leave their Work settings unchanged.</BWT_Workload_PawnOutsideTooltip>
+<BWT_Workload_PawnExcludedTooltip>This colonist is excluded from this application. Their Work settings will not change.</BWT_Workload_PawnExcludedTooltip>
+<BWT_Workload_PawnMissingTooltip>This workload includes a colonist who is not currently available.</BWT_Workload_PawnMissingTooltip>
+<BWT_Workload_OrderUndoUnavailable>You cannot undo or redo specific-job order while previewing a workload.</BWT_Workload_OrderUndoUnavailable>
+<BWT_Workload_FluffyScheduleUnavailable>Fluffy controls these hourly priorities, so Better Work Tab cannot change them here.</BWT_Workload_FluffyScheduleUnavailable>
+<BWT_Workload_SleekCellUnavailable>Sleek controls this priority cell, so Better Work Tab cannot change it in the workload preview.</BWT_Workload_SleekCellUnavailable>
+<BWT_Workload_FluffySpecificJobUnavailable>Fluffy controls this specific-job column, so Better Work Tab cannot change it in the workload preview.</BWT_Workload_FluffySpecificJobUnavailable>
+<BWT_Workload_FluffySchedulePreviewBlocked>Close the workload preview before changing Fluffy's hourly priorities.</BWT_Workload_FluffySchedulePreviewBlocked>
+<BWT_Workload_FluffyScheduleHidden>Fluffy's hourly-priority editor is hidden while the workload preview is open.</BWT_Workload_FluffyScheduleHidden>
+<BWT_Workload_MoveSpecificJobUnavailable>You cannot move a specific job to another Work type while previewing a workload.</BWT_Workload_MoveSpecificJobUnavailable>
+<BWT_Workload_SharedSpecificJobOrderUnavailable>Shared specific-job ordering is unavailable during a workload preview. Open a colonist's specific-job menu to preview changes for that colonist.</BWT_Workload_SharedSpecificJobOrderUnavailable>
+<BWT_Workload_ClearSpecificJobPriority>Clear this workload priority</BWT_Workload_ClearSpecificJobPriority>
+<BWT_Workload_LeaveSpecificJobPriorityUnchanged>Do not change this priority</BWT_Workload_LeaveSpecificJobPriorityUnchanged>
+<BWT_Workload_SaveDisplayedSpecificJobPriority>Save the displayed priority in this workload</BWT_Workload_SaveDisplayedSpecificJobPriority>
+<BWT_Workload_ClearSpecificJobOrder>Clear this workload order</BWT_Workload_ClearSpecificJobOrder>
+<BWT_Workload_LeaveSpecificJobOrderUnchanged>Do not change this order</BWT_Workload_LeaveSpecificJobOrderUnchanged>
+<BWT_Workload_SaveDisplayedSpecificJobOrder>Save the displayed order in this workload</BWT_Workload_SaveDisplayedSpecificJobOrder>
+<BWT_Workload_SpecificJobOrderInvalid>Better Work Tab could not read the current specific-job order.</BWT_Workload_SpecificJobOrderInvalid>
+<BWT_Workload_SpecificJobOrderChanged>The specific-job order changed before Better Work Tab could update the preview. Try again.</BWT_Workload_SpecificJobOrderChanged>
+<BWT_Workload_SpecificJobMoveInvalid>Better Work Tab could not move that specific job.</BWT_Workload_SpecificJobMoveInvalid>
 
 
 

--- a/Languages/English/Keyed/RuleBuilder.xml
+++ b/Languages/English/Keyed/RuleBuilder.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
   <!-- Window titles -->
-  <BWT_RulesetBuilder>Ruleset Builder</BWT_RulesetBuilder>
-  <BWT_RuleBuilder_Title>Ruleset Builder</BWT_RuleBuilder_Title>
-  <BWT_RuleBuilder_OpenBuilder>Ruleset Builder...</BWT_RuleBuilder_OpenBuilder>
-  <BWT_RuleBuilder_ManageRulesets>Manage Rulesets</BWT_RuleBuilder_ManageRulesets>
-  <BWT_RuleBuilder_ManageRulesetsClassic>Manage Rulesets (classic)...</BWT_RuleBuilder_ManageRulesetsClassic>
+  <BWT_RulesetBuilder>Rule Builder</BWT_RulesetBuilder>
+  <BWT_RuleBuilder_Title>Rule Builder</BWT_RuleBuilder_Title>
+  <BWT_RuleBuilder_OpenBuilder>Open Rule Builder...</BWT_RuleBuilder_OpenBuilder>
+  <BWT_RuleBuilder_ManageRulesets>Manage rulesets</BWT_RuleBuilder_ManageRulesets>
+  <BWT_RuleBuilder_ManageRulesetsClassic>Manage classic rulesets...</BWT_RuleBuilder_ManageRulesetsClassic>
   <BWT_RuleBuilder_Back>Back</BWT_RuleBuilder_Back>
   <BWT_RuleBuilder_EditingRulesFor>Editing rules for {0}</BWT_RuleBuilder_EditingRulesFor>
   <BWT_New>New</BWT_New>
 
   <!-- Column headers -->
-  <BWT_SelectPriority>Select a priority level:</BWT_SelectPriority>
+  <BWT_SelectPriority>Select a priority level</BWT_SelectPriority>
   <BWT_SelectPriorityFirst>Select a priority level first</BWT_SelectPriorityFirst>
 
   <!-- Conditions -->
@@ -19,7 +19,7 @@
   <BWT_AddConditionInstructions>Click "+ Add condition set" below to create rules.</BWT_AddConditionInstructions>
   <BWT_AddConditionSet>Add condition set</BWT_AddConditionSet>
   <BWT_AddConditionSet_Tooltip>Create a new set of conditions that will assign this priority to matching pawns.</BWT_AddConditionSet_Tooltip>
-  <BWT_ConditionsFor>Conditions for:</BWT_ConditionsFor>
+  <BWT_ConditionsFor>Conditions for</BWT_ConditionsFor>
 
   <!-- Priorities -->
   <BWT_Priority_Disabled>Disabled (0)</BWT_Priority_Disabled>
@@ -28,7 +28,7 @@
   <BWT_Priority_Normal>Normal Priority (3)</BWT_Priority_Normal>
   <BWT_Priority_Low>Low Priority (4)</BWT_Priority_Low>
 
-  <BWT_Priority_Disabled_Desc>This pawn will not be assigned to this work type.</BWT_Priority_Disabled_Desc>
+  <BWT_Priority_Disabled_Desc>This colonist will not be assigned to this Work type.</BWT_Priority_Disabled_Desc>
   <BWT_Priority_Highest_Desc>Highest priority. This pawn will be assigned first.</BWT_Priority_Highest_Desc>
   <BWT_Priority_High_Desc>High priority. This pawn will be assigned before normal priority pawns.</BWT_Priority_High_Desc>
   <BWT_Priority_Normal_Desc>Normal priority. Standard assignment.</BWT_Priority_Normal_Desc>
@@ -36,19 +36,21 @@
   <BWT_Priority_Extended>Priority ({0})</BWT_Priority_Extended>
   <BWT_Priority_Extended_Desc>Extended priority {0}. Higher numbers are lower priority and run after smaller non-zero values.</BWT_Priority_Extended_Desc>
   <BWT_NoPrioritiesConfigured>No priorities configured.</BWT_NoPrioritiesConfigured>
-  <BWT_RuleCountConditionSets>{0} condition set(s)</BWT_RuleCountConditionSets>
+  <BWT_RuleCountConditionSets>Condition sets: {0}</BWT_RuleCountConditionSets>
   <BWT_NoConditionsSetShort>No conditions set</BWT_NoConditionsSetShort>
   <BWT_ClickToSelect>Click to select</BWT_ClickToSelect>
-  <BWT_PriorityInput_Label>Priority:</BWT_PriorityInput_Label>
+  <BWT_PriorityInput_Label>Priority</BWT_PriorityInput_Label>
+  <BWT_PriorityInput_RangeHint>0-{0} (scroll to adjust by 1)</BWT_PriorityInput_RangeHint>
+  <BWT_PriorityInput_RangeTooltip>Enter a priority from 0 to {0}. Scroll to adjust it by 1.</BWT_PriorityInput_RangeTooltip>
   <BWT_KeepPriority>Keep</BWT_KeepPriority>
   <BWT_PickPriority>Pick...</BWT_PickPriority>
   <BWT_PriorityInput_Tooltip>Pick or enter a priority from 0 to {0}. The main column only keeps configured or selected priorities visible.</BWT_PriorityInput_Tooltip>
   <BWT_PriorityPicker_SelectPriority>Select priority</BWT_PriorityPicker_SelectPriority>
   <BWT_PriorityPicker_Recent>Recent</BWT_PriorityPicker_Recent>
-  <BWT_PriorityPicker_Bucket>Bucket: {0}</BWT_PriorityPicker_Bucket>
+  <BWT_PriorityPicker_Bucket>Range: {0}</BWT_PriorityPicker_Bucket>
   <BWT_PriorityPicker_BucketHint>Use this when the exact number is not visible in the main list.</BWT_PriorityPicker_BucketHint>
   <BWT_PriorityPicker_Picked>Picked</BWT_PriorityPicker_Picked>
-  <BWT_PriorityPicker_FooterHint>Esc cancels - Enter confirms - arrows move by one</BWT_PriorityPicker_FooterHint>
+  <BWT_PriorityPicker_FooterHint>Esc cancels. Enter confirms. Arrow keys change the value by one.</BWT_PriorityPicker_FooterHint>
 
   <!-- Condition categories -->
   <BWT_Category_Skill>Skill-Based</BWT_Category_Skill>
@@ -79,18 +81,32 @@
   <BWT_Any>Any</BWT_Any>
   <BWT_BiotechRequired>Requires Biotech DLC</BWT_BiotechRequired>
   
-  <BWT_RenameRuleset>Rename Ruleset</BWT_RenameRuleset>
+  <BWT_RenameRuleset>Rename ruleset</BWT_RenameRuleset>
   <BWT_Rename>Rename</BWT_Rename>
   <BWT_Confirm>Confirm</BWT_Confirm>
   <BWT_Cancel>Cancel</BWT_Cancel>
-  <BWT_DeleteRuleset>Delete Ruleset</BWT_DeleteRuleset>
+  <BWT_DeleteRuleset>Delete ruleset</BWT_DeleteRuleset>
   <BWT_DeleteRulesetConfirm>Are you sure? Deleting a ruleset is irreversible.</BWT_DeleteRulesetConfirm>
-  <BWT_NewRule>New Rule</BWT_NewRule>
-  <BWT_DuplicateRule>Duplicate Rule</BWT_DuplicateRule>
+  <BWT_NewRule>New rule</BWT_NewRule>
+  <BWT_DuplicateRule>Duplicate rule</BWT_DuplicateRule>
   <BWT_NoRulesInRuleset>No rules in ruleset</BWT_NoRulesInRuleset>
   <BWT_DropHere>Drop here to duplicate</BWT_DropHere>
-  <BWT_DragToDuplicate>Drag to duplicate these rules to another work type or priority.</BWT_DragToDuplicate>
+  <BWT_DragToDuplicate>Drag to copy these rules to another Work type or priority.</BWT_DragToDuplicate>
+  <BWT_RuleDrag_Handle>⇄ Drag</BWT_RuleDrag_Handle>
+  <BWT_RuleDrag_Count>Rules: {0}</BWT_RuleDrag_Count>
+  <BWT_RuleDrag_From>From {0}</BWT_RuleDrag_From>
+  <BWT_RuleDrag_Copying>Copying {0}</BWT_RuleDrag_Copying>
   <BWT_Done>Done</BWT_Done>
+  <BWT_Duplicate>Duplicate</BWT_Duplicate>
+  <BWT_ManageRules>Manage rules</BWT_ManageRules>
+  <BWT_NoRuleSelected>No rule selected</BWT_NoRuleSelected>
+  <BWT_Unassigned>Unassigned</BWT_Unassigned>
+  <BWT_MissingSavedValue>"{0}" (missing)</BWT_MissingSavedValue>
+  <BWT_NestedRulesNotSupported>Nested rules are not supported.</BWT_NestedRulesNotSupported>
+  <BWT_ConfigureFromConditionMenu>Configure from the condition menu</BWT_ConfigureFromConditionMenu>
+  <BWT_MoveRuleUp>Move rule up</BWT_MoveRuleUp>
+  <BWT_MoveRuleDown>Move rule down</BWT_MoveRuleDown>
+  <BWT_OK>OK</BWT_OK>
   <BWT_Apply>Apply</BWT_Apply>
   <BWT_RuleBuilder2_SleekTranslation_Title>Sleek priority compatibility</BWT_RuleBuilder2_SleekTranslation_Title>
   <BWT_RuleBuilder2_SleekTranslation_Apply>Apply translated rules</BWT_RuleBuilder2_SleekTranslation_Apply>
@@ -99,12 +115,12 @@
   <BWT_Change>Change</BWT_Change>
   <BWT_Edit>Edit</BWT_Edit>
   <BWT_Delete>Delete</BWT_Delete>
-  <BWT_SubWork_MoveSpecificJobToWork>Move specific job to {0}</BWT_SubWork_MoveSpecificJobToWork>
+  <BWT_SubWork_MoveSpecificJobToWork>Move specific job to Work type {0}</BWT_SubWork_MoveSpecificJobToWork>
   <BWT_SubWork_MoveSpecificJobSameWork>Already in this Work</BWT_SubWork_MoveSpecificJobSameWork>
   <BWT_SubWork_MoveSpecificJobFailed>Could not move specific job: {0}</BWT_SubWork_MoveSpecificJobFailed>
   <BWT_SubWork_MoveSpecificJobFailedNoReason>Could not move specific job.</BWT_SubWork_MoveSpecificJobFailedNoReason>
   <BWT_RuleBuilder2_Title>Rule Builder 2.0</BWT_RuleBuilder2_Title>
-  <BWT_RuleBuilder2_OpenClassic>Open classic ruleset builder...</BWT_RuleBuilder2_OpenClassic>
+  <BWT_RuleBuilder2_OpenClassic>Open classic Rule Builder...</BWT_RuleBuilder2_OpenClassic>
   <BWT_RuleBuilder2_Dashboard>Rules</BWT_RuleBuilder2_Dashboard>
   <BWT_RuleBuilder2_Enabled>Enabled</BWT_RuleBuilder2_Enabled>
   <BWT_RuleBuilder2_CreateBlank>Create blank ruleset</BWT_RuleBuilder2_CreateBlank>
@@ -118,7 +134,7 @@
   <BWT_RuleBuilder2_GenerateDraft_Tooltip>Suggest rules from the current Work tab. Keep, edit, or skip each one before saving.</BWT_RuleBuilder2_GenerateDraft_Tooltip>
   <BWT_RuleBuilder2_AddRule_Tooltip>Create a blank rule and open it for editing.</BWT_RuleBuilder2_AddRule_Tooltip>
   <BWT_RuleBuilder2_AddRuleMenu_Tooltip>Add a blank rule or copy rules from another ruleset.</BWT_RuleBuilder2_AddRuleMenu_Tooltip>
-  <BWT_RuleBuilder2_More_Tooltip>Ruleset tools: import classic rules, copy default, export for classic rules, or open the classic builder.</BWT_RuleBuilder2_More_Tooltip>
+  <BWT_RuleBuilder2_More_Tooltip>Import classic rules, copy the default ruleset, export classic-compatible rules, or open the classic Rule Builder.</BWT_RuleBuilder2_More_Tooltip>
   <BWT_RuleBuilder2_ImportShort>Import</BWT_RuleBuilder2_ImportShort>
   <BWT_RuleBuilder2_DashboardHint>Ruleset state</BWT_RuleBuilder2_DashboardHint>
   <BWT_RuleBuilder2_ImportClassic>Import or migrate classic rules</BWT_RuleBuilder2_ImportClassic>
@@ -133,11 +149,11 @@
   <BWT_RuleBuilder2_StatConfirmed>saved</BWT_RuleBuilder2_StatConfirmed>
   <BWT_RuleBuilder2_StatConfirmed_Tooltip>Saved rules are part of the active ruleset and can be applied.</BWT_RuleBuilder2_StatConfirmed_Tooltip>
   <BWT_RuleBuilder2_StatReview>draft</BWT_RuleBuilder2_StatReview>
-  <BWT_RuleBuilder2_StatReview_Tooltip>Draft rules still need Work type, conditions, or action details before saving.</BWT_RuleBuilder2_StatReview_Tooltip>
+  <BWT_RuleBuilder2_StatReview_Tooltip>Draft rules need a Work type, conditions, or action details before you can save them.</BWT_RuleBuilder2_StatReview_Tooltip>
   <BWT_RuleBuilder2_StatSubWork>jobs</BWT_RuleBuilder2_StatSubWork>
   <BWT_RuleBuilder2_StatSubWork_Tooltip>Rules targeting one specific job instead of a whole Work type.</BWT_RuleBuilder2_StatSubWork_Tooltip>
   <BWT_RuleBuilder2_StatSchedules>schedules</BWT_RuleBuilder2_StatSchedules>
-  <BWT_RuleBuilder2_StatSchedules_Tooltip>Rules that change priority by hour instead of using one all-day priority.</BWT_RuleBuilder2_StatSchedules_Tooltip>
+  <BWT_RuleBuilder2_StatSchedules_Tooltip>Rules that use hourly priorities instead of one all-day priority.</BWT_RuleBuilder2_StatSchedules_Tooltip>
   <BWT_RuleBuilder2_TableOn>On</BWT_RuleBuilder2_TableOn>
   <BWT_RuleBuilder2_TableTarget>What</BWT_RuleBuilder2_TableTarget>
   <BWT_RuleBuilder2_TableConditions>Conditions</BWT_RuleBuilder2_TableConditions>
@@ -153,7 +169,7 @@
   <BWT_RuleBuilder2_BackToRules>Back to rules</BWT_RuleBuilder2_BackToRules>
   <BWT_RuleBuilder2_ResumeDrafts>Review suggestions ({0} left)</BWT_RuleBuilder2_ResumeDrafts>
   <BWT_RuleBuilder2_DraftNoReason>Suggested from the current Work tab.</BWT_RuleBuilder2_DraftNoReason>
-  <BWT_RuleBuilder2_DraftImpact>{0} match, {1} change</BWT_RuleBuilder2_DraftImpact>
+  <BWT_RuleBuilder2_DraftImpact>Matches: {0}. Changes: {1}.</BWT_RuleBuilder2_DraftImpact>
   <BWT_RuleBuilder2_Preview>Map check</BWT_RuleBuilder2_Preview>
   <BWT_RuleBuilder2_RuleCard>Rule</BWT_RuleBuilder2_RuleCard>
   <BWT_RuleBuilder2_Unconfirmed>Editing. Save this rule to include it in the ruleset.</BWT_RuleBuilder2_Unconfirmed>
@@ -161,11 +177,11 @@
   <BWT_RuleBuilder2_ReadOnlySentence>{0}: {2} for {1}.</BWT_RuleBuilder2_ReadOnlySentence>
   <BWT_RuleBuilder2_SaveRule>Save rule</BWT_RuleBuilder2_SaveRule>
   <BWT_RuleBuilder2_DeleteRule>Delete rule</BWT_RuleBuilder2_DeleteRule>
-  <BWT_RuleBuilder2_TargetBlockTitle>What to set</BWT_RuleBuilder2_TargetBlockTitle>
-  <BWT_RuleBuilder2_StepTarget>1. Choose Work</BWT_RuleBuilder2_StepTarget>
-  <BWT_RuleBuilder2_WorkTabHint>Hover the Work tab to preview. Click a header or priority cell to select it; use the drilldown shortcut for specific jobs.</BWT_RuleBuilder2_WorkTabHint>
+  <BWT_RuleBuilder2_TargetBlockTitle>Choose a target</BWT_RuleBuilder2_TargetBlockTitle>
+  <BWT_RuleBuilder2_StepTarget>1. Choose a Work type</BWT_RuleBuilder2_StepTarget>
+  <BWT_RuleBuilder2_WorkTabHint>Hover the Work tab to preview. Click a header or priority cell to select it. Use the configured shortcut to open specific jobs.</BWT_RuleBuilder2_WorkTabHint>
   <BWT_RuleBuilder2_TargetNoMatches>No matching work found.</BWT_RuleBuilder2_TargetNoMatches>
-  <BWT_RuleBuilder2_TargetWholeWork>whole Work</BWT_RuleBuilder2_TargetWholeWork>
+  <BWT_RuleBuilder2_TargetWholeWork>whole Work type</BWT_RuleBuilder2_TargetWholeWork>
   <BWT_RuleBuilder2_TargetSpecificJob>specific job</BWT_RuleBuilder2_TargetSpecificJob>
   <BWT_RuleBuilder2_TargetWholeWorkTooltip>Select the whole Work type, or expand it to choose a specific job.</BWT_RuleBuilder2_TargetWholeWorkTooltip>
   <BWT_RuleBuilder2_TargetSpecificJobTooltip>Select only this specific job.</BWT_RuleBuilder2_TargetSpecificJobTooltip>
@@ -189,22 +205,22 @@
   <BWT_RuleBuilder2_StepAction>3. Choose action</BWT_RuleBuilder2_StepAction>
   <BWT_RuleBuilder2_ActionBlockTitle>Action</BWT_RuleBuilder2_ActionBlockTitle>
   <BWT_RuleBuilder2_ScheduleHint>No schedule</BWT_RuleBuilder2_ScheduleHint>
-  <BWT_RuleBuilder2_ScheduleHint_Tooltip>Choose Daily plan to set a priority for each hour.</BWT_RuleBuilder2_ScheduleHint_Tooltip>
+  <BWT_RuleBuilder2_ScheduleHint_Tooltip>Choose Daily plan to set hourly priorities.</BWT_RuleBuilder2_ScheduleHint_Tooltip>
   <BWT_RuleBuilder2_ActionModeAllDay>One priority</BWT_RuleBuilder2_ActionModeAllDay>
   <BWT_RuleBuilder2_ActionModeAllDay_Tooltip>Use one priority all day for the selected Work or specific job.</BWT_RuleBuilder2_ActionModeAllDay_Tooltip>
   <BWT_RuleBuilder2_ActionModeDailyPlan>Daily plan</BWT_RuleBuilder2_ActionModeDailyPlan>
-  <BWT_RuleBuilder2_ActionModeDailyPlan_Tooltip>Set priorities by hour for the selected Work or specific job.</BWT_RuleBuilder2_ActionModeDailyPlan_Tooltip>
+  <BWT_RuleBuilder2_ActionModeDailyPlan_Tooltip>Set hourly priorities for the selected Work type or specific job.</BWT_RuleBuilder2_ActionModeDailyPlan_Tooltip>
   <BWT_RuleBuilder2_ActionModeDisable>Disable</BWT_RuleBuilder2_ActionModeDisable>
   <BWT_RuleBuilder2_ActionModeDisable_Tooltip>Set the selected Work or specific job to disabled when this rule applies.</BWT_RuleBuilder2_ActionModeDisable_Tooltip>
   <BWT_RuleBuilder2_ActionModeFollow>Follow default</BWT_RuleBuilder2_ActionModeFollow>
-  <BWT_RuleBuilder2_ActionModeFollow_Tooltip>Preview-only for saved legacy cards. New rules should set a priority, daily plan, or disable the selected Work or specific job.</BWT_RuleBuilder2_ActionModeFollow_Tooltip>
+  <BWT_RuleBuilder2_ActionModeFollow_Tooltip>This is only for saved legacy cards. New rules should set a priority, daily plan, or disable the selected Work type or specific job.</BWT_RuleBuilder2_ActionModeFollow_Tooltip>
   <BWT_RuleBuilder2_ActionScopeWholeWork>Whole Work</BWT_RuleBuilder2_ActionScopeWholeWork>
   <BWT_RuleBuilder2_ActionScopeSpecificJob>Specific job</BWT_RuleBuilder2_ActionScopeSpecificJob>
-  <BWT_RuleBuilder2_ScheduleWorkHint>Drag hours to paint</BWT_RuleBuilder2_ScheduleWorkHint>
-  <BWT_RuleBuilder2_ScheduleSubJobHint>Drag hours to paint</BWT_RuleBuilder2_ScheduleSubJobHint>
+  <BWT_RuleBuilder2_ScheduleWorkHint>Drag across hours to set priorities</BWT_RuleBuilder2_ScheduleWorkHint>
+  <BWT_RuleBuilder2_ScheduleSubJobHint>Drag across hours to set priorities</BWT_RuleBuilder2_ScheduleSubJobHint>
   <BWT_RuleBuilder2_ScheduleFillAll>Fill all</BWT_RuleBuilder2_ScheduleFillAll>
   <BWT_RuleBuilder2_ScheduleWorkday>Workday</BWT_RuleBuilder2_ScheduleWorkday>
-  <BWT_RuleBuilder2_SchedulePaintTooltip>Hour {0}. Left-click moves toward priority 1; right-click moves toward lower or disabled priority. Drag to paint.</BWT_RuleBuilder2_SchedulePaintTooltip>
+  <BWT_RuleBuilder2_SchedulePaintTooltip>Hour {0}. Left-click moves toward priority 1. Right-click moves toward a lower priority or disabled. Drag across hours to set priorities.</BWT_RuleBuilder2_SchedulePaintTooltip>
   <BWT_RuleBuilder2_StepPreview>4. Map check</BWT_RuleBuilder2_StepPreview>
   <BWT_RuleBuilder2_MapCheckBlockTitle>Map check</BWT_RuleBuilder2_MapCheckBlockTitle>
   <BWT_RuleBuilder2_RunPreview>Check map</BWT_RuleBuilder2_RunPreview>
@@ -266,17 +282,17 @@
   <BWT_RuleBuilder2_Matched>Matched</BWT_RuleBuilder2_Matched>
   <BWT_RuleBuilder2_NotMatched>Not matched</BWT_RuleBuilder2_NotMatched>
   <BWT_RuleBuilder2_CurrentToNew>Current {0} -&gt; {1}</BWT_RuleBuilder2_CurrentToNew>
-  <BWT_RuleBuilder2_ApplyStatus>{0} change(s)</BWT_RuleBuilder2_ApplyStatus>
-  <BWT_RuleBuilder2_ApplyStatusWarnings>{0} change(s); {1} warning(s)</BWT_RuleBuilder2_ApplyStatusWarnings>
+  <BWT_RuleBuilder2_ApplyStatus>Changes: {0}</BWT_RuleBuilder2_ApplyStatus>
+  <BWT_RuleBuilder2_ApplyStatusWarnings>Changes: {0}. Warnings: {1}.</BWT_RuleBuilder2_ApplyStatusWarnings>
   <BWT_RuleBuilder2_ActionSetPriority>Set priority</BWT_RuleBuilder2_ActionSetPriority>
   <BWT_RuleBuilder2_ActionDisable>Disable Work</BWT_RuleBuilder2_ActionDisable>
   <BWT_RuleBuilder2_ActionFollowGlobal>Follow global/default</BWT_RuleBuilder2_ActionFollowGlobal>
-  <BWT_RuleBuilder2_ActionSetTimeSchedule>Set time schedule</BWT_RuleBuilder2_ActionSetTimeSchedule>
+  <BWT_RuleBuilder2_ActionSetTimeSchedule>Set hourly priorities</BWT_RuleBuilder2_ActionSetTimeSchedule>
   <BWT_RuleBuilder2_ActionSetSubWorkSchedule>Set specific job schedule</BWT_RuleBuilder2_ActionSetSubWorkSchedule>
   <BWT_RuleBuilder2_ActionText_NoAction>No action</BWT_RuleBuilder2_ActionText_NoAction>
   <BWT_RuleBuilder2_ActionText_Disable>Disable {0} for matching colonists</BWT_RuleBuilder2_ActionText_Disable>
   <BWT_RuleBuilder2_ActionText_FollowGlobal>Follow global/default priority for {0}</BWT_RuleBuilder2_ActionText_FollowGlobal>
-  <BWT_RuleBuilder2_ActionText_Schedule>Set {0} to scheduled priorities</BWT_RuleBuilder2_ActionText_Schedule>
+  <BWT_RuleBuilder2_ActionText_Schedule>Set hourly priorities for {0}</BWT_RuleBuilder2_ActionText_Schedule>
   <BWT_RuleBuilder2_ActionText_SetPriority>Set {0} to priority {1}</BWT_RuleBuilder2_ActionText_SetPriority>
   <BWT_RuleBuilder2_ActionText_NoActionShort>choose an action</BWT_RuleBuilder2_ActionText_NoActionShort>
   <BWT_RuleBuilder2_ActionText_DisableShort>disable it</BWT_RuleBuilder2_ActionText_DisableShort>
@@ -293,8 +309,8 @@
   <BWT_RuleBuilder2_ConditionText_Gender>Gender is {0}</BWT_RuleBuilder2_ConditionText_Gender>
   <BWT_RuleBuilder2_ConditionText_ExistingPriorityAtLeast>Current priority is at least {0}</BWT_RuleBuilder2_ConditionText_ExistingPriorityAtLeast>
   <BWT_RuleBuilder2_ConditionText_ExistingPriorityEquals>Current priority is {0}</BWT_RuleBuilder2_ConditionText_ExistingPriorityEquals>
-  <BWT_RuleBuilder2_ConditionText_Assigned>Assigned to this work</BWT_RuleBuilder2_ConditionText_Assigned>
-  <BWT_RuleBuilder2_ConditionText_NotAssigned>Not assigned to this work</BWT_RuleBuilder2_ConditionText_NotAssigned>
+  <BWT_RuleBuilder2_ConditionText_Assigned>Assigned to this Work type</BWT_RuleBuilder2_ConditionText_Assigned>
+  <BWT_RuleBuilder2_ConditionText_NotAssigned>Not assigned to this Work type</BWT_RuleBuilder2_ConditionText_NotAssigned>
   <BWT_RuleBuilder2_ConditionText_HighestSkill>Has the highest relevant skill among colonists</BWT_RuleBuilder2_ConditionText_HighestSkill>
   <BWT_RuleBuilder2_ConditionText_TopWorkTypes>This is among the pawn's top {0} skilled Work types</BWT_RuleBuilder2_ConditionText_TopWorkTypes>
   <BWT_RuleBuilder2_ConditionText_NaturalAlways>This Work type is naturally always active</BWT_RuleBuilder2_ConditionText_NaturalAlways>
@@ -321,8 +337,8 @@
   <BWT_RuleBuilder2_NewRulesetName>New ruleset</BWT_RuleBuilder2_NewRulesetName>
   <BWT_RuleBuilder2_NewRulesetDescription>Blank ruleset.</BWT_RuleBuilder2_NewRulesetDescription>
   <BWT_RuleBuilder2_NoClassicRules>No classic rulesets found</BWT_RuleBuilder2_NoClassicRules>
-  <BWT_RuleBuilder2_ExportClassicStatus>{0} classic rule(s) exported</BWT_RuleBuilder2_ExportClassicStatus>
-  <BWT_RuleBuilder2_ExportClassicStatusWarnings>{0} classic rule(s) exported; {1} warning(s)</BWT_RuleBuilder2_ExportClassicStatusWarnings>
+  <BWT_RuleBuilder2_ExportClassicStatus>Classic rules exported: {0}</BWT_RuleBuilder2_ExportClassicStatus>
+  <BWT_RuleBuilder2_ExportClassicStatusWarnings>Classic rules exported: {0}. Warnings: {1}.</BWT_RuleBuilder2_ExportClassicStatusWarnings>
   <BWT_RuleBuilder2_ExportClassicNoRules>No saved rules could be exported to the classic format</BWT_RuleBuilder2_ExportClassicNoRules>
   <BWT_RuleBuilder2_Category_Skills>Skills</BWT_RuleBuilder2_Category_Skills>
   <BWT_RuleBuilder2_Category_Passions>Passions</BWT_RuleBuilder2_Category_Passions>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Better Work Tab 2.0
 
-Better Work Tab expands RimWorld's Work tab with faster setup, finer job control, reusable rules, and flexible layouts.
+Better Work Tab adds drag-and-drop ordering, specific-job controls, reusable rules, time-based priorities, and layout options to RimWorld's Work tab.
 
 ## Transpiler architecture
 
@@ -17,19 +17,19 @@ is no longer used by BWT.
 
 ## What 2.0 adds
 
-- **Guided tutorial** — choose a focused “What’s new in 2.0” course or the complete Better Work Tab walkthrough. Lessons point to the relevant controls and guide the required actions.
-- **Rule Builder 2.0** — create card-based rulesets from work targets, conditions, priority actions, and map checks; preview matches before applying. The classic rule builder remains available.
-- **Specific-job drilldown** — open a Work type into its individual jobs, set shared or pawn-specific priorities, rename jobs, reorder them, and move them between Work columns.
-- **Two specific-job layouts** — use a clean focused full-tab view or Fluffy-inspired right-expanding columns.
-- **Time-priority schedules** — Ctrl-click a priority cell to plan different priorities across all 24 hours, including individual specific jobs. Schedules support copy and paste.
-- **Priority ranges** — keep vanilla priorities, let BWT choose automatically, delegate to a compatible provider, or let BWT manage priorities up to 99.
-- **Fluffy Work Tab coexistence** — choose which mod owns the Work tab. When BWT owns it, compatible Fluffy columns and familiar top controls can remain available.
+- **Guided tutorial**: Choose the focused "What's new in 2.0" course or the complete Better Work Tab walkthrough. Lessons point to the relevant controls and actions.
+- **Rule Builder 2.0**: Create card-based rulesets with work targets, conditions, priority actions, and map checks. Preview matches before applying. The classic rule builder remains available.
+- **Specific-job view**: Open a Work type to manage its individual jobs. Set shared or pawn-specific priorities, rename and reorder jobs, and move them between Work columns.
+- **Two specific-job layouts**: Use a focused full-tab view or Fluffy-inspired right-expanding columns.
+- **Time-priority schedules**: Ctrl-click a priority cell to set priorities for all 24 hours, including individual specific jobs. Schedules support copy and paste.
+- **Priority ranges**: Keep vanilla priorities, let BWT choose automatically, delegate to a compatible provider, or let BWT manage priorities up to 99.
+- **Fluffy Work Tab coexistence**: Choose which mod owns the Work tab. When BWT owns it, compatible Fluffy columns and top controls remain available.
 
-Every major 2.0 system is independently toggleable in Mod Settings.
+You can toggle each major 2.0 system independently in Mod Settings.
 
 ## Work-tab essentials
 
-- Drag pawn rows and Work columns to reorder them; layouts persist.
+- Drag pawn rows and Work columns to reorder them. The layout is saved.
 - Hold Shift for color-coded skill levels and best-pawn indicators.
 - Save and restore whole-colony priority layouts as workloads.
 - Organize pawns with named, colored, collapsible dividers.
@@ -43,14 +43,14 @@ Every major 2.0 system is independently toggleable in Mod Settings.
 
 BWT handles new 2.0 installs and upgrades from the public 1.0.5 release differently:
 
-- New 2.0 installs start with specific-job drilldown, Rule Builder 2.0, time-priority schedules, and the guided tutorial enabled.
-- Upgrades keep the new 2.0 features disabled initially. The upgrade prompt can enable them through a tutorial course, or the familiar 1.x interface can remain in place while features are enabled later from settings.
+- New 2.0 installs start with the specific-job view, Rule Builder 2.0, time-priority schedules, and the guided tutorial enabled.
+- Upgrades keep the new 2.0 features disabled initially. The upgrade prompt can enable them through a tutorial course. You can also keep the 1.x interface and enable features later in settings.
 
-Saved 1.x preferences and rulesets are preserved. BWT applies the settings update once; importing settings later does not repeat the upgrade process. Back up important saves before changing the mod list.
+Saved 1.x preferences and rulesets are preserved. BWT applies the settings update once. Importing settings later does not repeat it. Back up important saves before changing the mod list.
 
 ## Specific jobs and Fluffy-style coverage
 
-Better Work Tab owns its specific-job priorities, ordering, schedules, and two presentation styles. Fluffy Work Tab is optional.
+Better Work Tab owns its specific-job priorities, ordering, schedules, and two layouts. Fluffy Work Tab is optional.
 
 | Capability | Better Work Tab 2.0 behavior |
 | --- | --- |
@@ -60,7 +60,7 @@ Better Work Tab owns its specific-job priorities, ordering, schedules, and two p
 | Priorities by hour | BWT 24-hour planner for Work types and specific jobs |
 | More priority levels | Configurable BWT range up to 99 |
 | Scroll priority editing | Optional for Work, specific-job, and scheduled priority cells |
-| Compact top controls | Uses installed Fluffy icons; optional BWT text substitutes work standalone |
+| Compact top controls | Uses installed Fluffy icons. Optional BWT text substitutes work without Fluffy. |
 | Mood, current job, favorite, and detailed-copy columns | Supplied by an installed compatible Fluffy Work Tab |
 
 Shift-click remains reserved for BWT's grouped column dragging, so it does not duplicate Fluffy's whole-row and whole-column shortcut exactly.
@@ -68,22 +68,22 @@ Shift-click remains reserved for BWT's grouped column dragging, so it does not d
 ## Compatibility
 
 - Requires [Harmony](https://steamcommunity.com/sharedfiles/filedetails/?id=2009463077).
-- Supports RimWorld 0.13 through 1.6; multiplayer support is limited to the versions identified in `About/About.xml`.
+- Supports RimWorld 0.13 through 1.6. Multiplayer support is limited to the versions identified in `About/About.xml`.
 - Compatible with all DLC and designed for modded Work types.
 - Supports [FSF] Complex Jobs ordering and Vanilla Skills Expanded passion conditions.
 - Fluffy Work Tab and maintained forks can coexist, with one mod selected as the Work-tab owner.
 - CompactWorkTab overlaps the same UI and should not be enabled together.
-- Other Work-tab overhauls may conflict; test before adding one to an existing save.
+- Other Work-tab overhauls may conflict. Test before adding one to an existing save.
 
 ## Performance
 
-The optimized Work-grid renderer uses caching, viewport culling, and targeted invalidation for large colonies. A vanilla-compatible renderer remains available as a fallback in advanced settings.
+The optimized Work-grid renderer uses caching, viewport culling, and targeted invalidation for large colonies. A vanilla-compatible renderer remains available in advanced settings.
 
 ## Credits
 
 - Colour picker by Karel Kroeze (MIT License)
-- Fluffy's Work Tab by Fluffy — UI inspiration and compatibility reference (MIT software/documentation); BWT does not bundle Fluffy's CC BY-SA art or sounds
-- Harmony team — patch framework
+- Fluffy's Work Tab by Fluffy: UI inspiration and compatibility reference. Its software and documentation are MIT licensed. BWT does not bundle its CC BY-SA art or sounds.
+- Harmony team: Patch framework
 - Full notices: [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
 
 ## Support

--- a/Source/DragDrop/ColumnDragHandler.cs
+++ b/Source/DragDrop/ColumnDragHandler.cs
@@ -626,7 +626,7 @@ namespace Better_Work_Tab.DragDrop
                 {
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.SpecificJobOrder,
-                        "Global sub-work layout ordering cannot be represented by a pawn-scoped preview key.");
+                        "BWT_Workload_SharedSpecificJobOrderUnavailable".Translate());
                     return;
                 }
 
@@ -706,7 +706,7 @@ namespace Better_Work_Tab.DragDrop
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOrder,
-                    "Cross-work-type specific-job moves are owned by the live layout service.");
+                    "BWT_Workload_MoveSpecificJobUnavailable".Translate());
                 return true;
             }
 

--- a/Source/Features/Patches/FloatMenuPatches.cs
+++ b/Source/Features/Patches/FloatMenuPatches.cs
@@ -285,7 +285,7 @@ namespace Better_Work_Tab.Patches
         {
             Patch_FloatMenuOptionProvider_WorkGivers_GetWorkGiverOptionFor.AdditionalOptions.Add(
                 new FloatMenuOption(
-                    "Open " + WorkTypeMenuLabel(workType) + " priority schedule",
+                    "BWT_HourlyPriorities_OpenForWorkType".Translate(WorkTypeMenuLabel(workType)),
                     () => TimePriorityScheduleEditor.OpenForFloatMenu(pawn, workType, workGiver),
                     orderInPriority: -1));
         }
@@ -342,8 +342,7 @@ namespace Better_Work_Tab.Patches
             if (WorkloadPreviewController.Current?.IsActive == true && windowPawn == null)
             {
                 Messages.Message(
-                    "Global/shared work-giver ordering is unavailable while a workload preview is active. " +
-                    "Open a pawn-specific submenu to stage pawn-local order changes.",
+                    "BWT_Workload_SharedSpecificJobOrderUnavailable".Translate(),
                     MessageTypeDefOf.RejectInput,
                     false);
                 return;

--- a/Source/Features/Patches/Patch_WorkPriority_DoCell_Unified.cs
+++ b/Source/Features/Patches/Patch_WorkPriority_DoCell_Unified.cs
@@ -191,7 +191,7 @@ namespace Better_Work_Tab.Patches
                 {
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.ParentPriority,
-                        "Sleek owns this visible cell and has no preview editor bridge.");
+                        "BWT_Workload_SleekCellUnavailable".Translate());
                     Event.current?.Use();
                     return false;
                 }
@@ -211,7 +211,7 @@ namespace Better_Work_Tab.Patches
                 {
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.SpecificJobOverride,
-                        "Fluffy owns this work-giver column and has no preview editor bridge.");
+                        "BWT_Workload_FluffySpecificJobUnavailable".Translate());
                     Event.current?.Use();
                     return false;
                 }
@@ -261,7 +261,7 @@ namespace Better_Work_Tab.Patches
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    "Fluffy's live scheduler owns the current Work-tab surface.");
+                    "BWT_Workload_FluffyScheduleUnavailable".Translate());
                 return false;
             }
 
@@ -1308,7 +1308,7 @@ namespace Better_Work_Tab.Patches
 
             WorkTabEffectiveStateRuntime.ReportBlocked(
                 WorkTabEffectiveStateDimension.Schedule,
-                "Fluffy's live scheduler cannot be opened or closed during preview.");
+                "BWT_Workload_FluffySchedulePreviewBlocked".Translate());
             __result = false;
             return false;
         }
@@ -1327,7 +1327,7 @@ namespace Better_Work_Tab.Patches
 
             WorkTabEffectiveStateRuntime.ReportBlocked(
                 WorkTabEffectiveStateDimension.Schedule,
-                "Fluffy's live scheduler input is blocked during preview.");
+                "BWT_Workload_FluffySchedulePreviewBlocked".Translate());
             evt?.Use();
             __result = true;
             return false;
@@ -1348,7 +1348,7 @@ namespace Better_Work_Tab.Patches
 
             WorkTabEffectiveStateRuntime.ReportBlocked(
                 WorkTabEffectiveStateDimension.Schedule,
-                "Fluffy-style scheduler surface is hidden during workload preview.");
+                "BWT_Workload_FluffyScheduleHidden".Translate());
             return false;
         }
     }

--- a/Source/Features/TimePriority/FluffyTimeScheduleAssigner.cs
+++ b/Source/Features/TimePriority/FluffyTimeScheduleAssigner.cs
@@ -298,7 +298,7 @@ namespace Better_Work_Tab.Features.TimePriority
                     {
                         WorkTabEffectiveStateRuntime.ReportBlocked(
                             WorkTabEffectiveStateDimension.Schedule,
-                            clearReason ?? "The projected hourly schedule could not be cleared.");
+                            clearReason ?? "BWT_HourlyPriorities_ClearRejected".Translate());
                         return false;
                     }
 
@@ -412,7 +412,7 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    reason ?? "The hourly schedule write was rejected.");
+                    reason ?? "BWT_HourlyPriorities_WriteRejected".Translate());
             }
 
             return accepted;
@@ -427,7 +427,7 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    reason ?? "The hourly schedule clear was rejected.");
+                    reason ?? "BWT_HourlyPriorities_ClearRejected".Translate());
             }
 
             return accepted;
@@ -470,14 +470,14 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 SelectWholeDay();
             }
-            TooltipHandler.TipRegion(wholeDayButton, "Select the whole day");
+            TooltipHandler.TipRegion(wholeDayButton, "BWT_HourlyPriorities_SelectWholeDay".Translate());
 
             if (FluffyWorkTabGateway.TryGetIcon(FluffyWorkTabIcon.Now, out Texture2D nowIcon) &&
                 Widgets.ButtonImage(nowButton, nowIcon, Color.white, GenUI.MouseoverColor))
             {
                 SelectHour(Find.CurrentMap != null ? GenLocalDate.HourOfDay(Find.CurrentMap) : 0, replace: true);
             }
-            TooltipHandler.TipRegion(nowButton, "Select the current hour");
+            TooltipHandler.TipRegion(nowButton, "BWT_HourlyPriorities_SelectCurrentHour".Translate());
         }
 
         private static void DrawHourBar(Rect bar)

--- a/Source/Features/TimePriority/TimePriorityScheduleEditor.cs
+++ b/Source/Features/TimePriority/TimePriorityScheduleEditor.cs
@@ -286,7 +286,7 @@ namespace Better_Work_Tab.Features.TimePriority
             }
 
             pawnId = _session.PawnIds[0];
-            ActiveDivider.DividerName = _session.TargetLabel + " time priorities";
+            ActiveDivider.DividerName = "BWT_HourlyPriorities_DividerName".Translate(_session.TargetLabel);
             ActiveDivider.Height = TransientDividerVisualHeight;
             ActiveDivider.IsCollapsed = false;
             divider = ActiveDivider;
@@ -702,7 +702,7 @@ namespace Better_Work_Tab.Features.TimePriority
                 {
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.Schedule,
-                        reason ?? "The hourly schedule write was rejected.");
+                        reason ?? "BWT_HourlyPriorities_WriteRejected".Translate());
                 }
 
                 if (accepted)
@@ -782,13 +782,13 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    "Schedule copy is unavailable while Better Work Tab does not own priority data.");
+                    "BWT_HourlyPriorities_CopyUnavailable".Translate());
                 return;
             }
 
             TimePriorityScheduleClipboard.CopyFrom(hit.Target, hit.FallbackPriority, hit.Label);
             TimePriorityScheduleTransferFeedback.StartCopy(hit.Target);
-            Messages.Message("Copied " + hit.Label + " time priorities.", MessageTypeDefOf.PositiveEvent, false);
+            Messages.Message("BWT_HourlyPriorities_Copied".Translate(hit.Label), MessageTypeDefOf.PositiveEvent, false);
         }
 
         private static void PasteSchedule(CopyPasteHit hit)
@@ -797,7 +797,7 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    "Schedule paste is unavailable while Better Work Tab does not own priority data.");
+                    "BWT_HourlyPriorities_PasteUnavailable".Translate());
                 return;
             }
 
@@ -818,12 +818,12 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    reason ?? "The schedule paste was rejected.");
+                    reason ?? "BWT_HourlyPriorities_PasteRejected".Translate());
                 return;
             }
 
             TimePriorityScheduleTransferFeedback.StartPaste(hit.Target, beforePriorities, afterPriorities, closeWhenComplete: true);
-            Messages.Message("Pasted " + snapshot.Label + " time priorities.", MessageTypeDefOf.PositiveEvent, false);
+            Messages.Message("BWT_HourlyPriorities_Pasted".Translate(snapshot.Label), MessageTypeDefOf.PositiveEvent, false);
         }
 
         private static void EnsureTargetVisibleForTransfer(CopyPasteHit hit)
@@ -932,7 +932,7 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    "Hourly schedule sessions are unavailable while Better Work Tab does not own priority data.");
+                    "BWT_HourlyPriorities_OpenUnavailable".Translate());
                 return;
             }
 
@@ -2145,8 +2145,11 @@ namespace Better_Work_Tab.Features.TimePriority
 
                 TooltipHandler.TipRegion(
                     drawRect,
-                    "Hour " + hour + ": priority " +
-                    (priority <= WorkPrioritySystem.DisabledPriority ? "disabled" : priority.ToString()));
+                    "BWT_HourlyPriorities_HourTooltip".Translate(
+                        hour,
+                        priority <= WorkPrioritySystem.DisabledPriority
+                            ? "BWT_Disabled".Translate().ToString()
+                            : priority.ToString()));
             }
         }
 

--- a/Source/Features/TimePriority/TimePriorityService.cs
+++ b/Source/Features/TimePriority/TimePriorityService.cs
@@ -288,7 +288,7 @@ namespace Better_Work_Tab.Features.TimePriority
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    "The active workload preview has no typed 24-hour schedule reader.");
+                    "BWT_Workload_HourlyPriorityUnavailable".Translate());
                 return true;
             }
 

--- a/Source/Features/Workloads/WorkloadNamers.cs
+++ b/Source/Features/Workloads/WorkloadNamers.cs
@@ -68,7 +68,7 @@ namespace Better_Work_Tab.Features.Workloads
             Rect rect = new Rect(inRect);
             Text.Font = GameFont.Medium;
             rect.height = Text.LineHeight + 10f;
-            Widgets.Label(rect, "Name New Workload");
+            Widgets.Label(rect, "BWT_Dialog_Workload_NameTitle".Translate());
             Text.Font = GameFont.Small;
             GUI.SetNextControlName("RenameField");
             string text = Widgets.TextField(new Rect(0f, rect.height, inRect.width, 35f), curName);
@@ -86,7 +86,7 @@ namespace Better_Work_Tab.Features.Workloads
                 Verse.UI.FocusControl("RenameField", this);
                 focusedRenameField = true;
             }
-            if (!(Widgets.ButtonText(new Rect(15f, inRect.height - 35f - 10f, inRect.width - 15f - 15f, 35f), "OK") || flag))
+            if (!(Widgets.ButtonText(new Rect(15f, inRect.height - 35f - 10f, inRect.width - 15f - 15f, 35f), "OK".Translate()) || flag))
             {
                 return;
             }

--- a/Source/Mod Support/OptionalModSettingsAvailability.cs
+++ b/Source/Mod Support/OptionalModSettingsAvailability.cs
@@ -1,5 +1,6 @@
 using System;
 using Spine.UI.SettingsFramework;
+using Verse;
 
 namespace Better_Work_Tab.ModSupport
 {
@@ -17,12 +18,14 @@ namespace Better_Work_Tab.ModSupport
             {
                 When = _ => isAvailable == null || !isAvailable(),
                 Reason = _ =>
-                    $"Requires {modName}.",
+                    "BWT_Settings_OptionalMod_Required".Translate(modName),
                 ExternalActionUrl = workshopUrl,
-                ExternalActionLabel = string.IsNullOrEmpty(workshopUrl) ? null : "Open Workshop",
+                ExternalActionLabel = string.IsNullOrEmpty(workshopUrl)
+                    ? null
+                    : "BWT_Settings_OptionalMod_OpenWorkshop".Translate(),
                 ExternalActionTooltip = string.IsNullOrEmpty(workshopUrl)
                     ? null
-                    : $"Requires {modName}. Click to open its Steam Workshop page."
+                    : "BWT_Settings_OptionalMod_WorkshopTooltip".Translate(modName)
             };
         }
     }

--- a/Source/PawnOrganizer/Layout/WorkTabLayoutController.cs
+++ b/Source/PawnOrganizer/Layout/WorkTabLayoutController.cs
@@ -941,7 +941,7 @@ namespace Better_Work_Tab.PawnOrganizer
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOrder,
-                    "Specific-job ordering is not projected in this workload preview; live reassignment order is not used.");
+                    "BWT_Workload_SpecificJobOrderUnavailable".Translate());
             }
             if (showSubWork)
             {

--- a/Source/UI/BetterWorkTabSettingsUI.cs
+++ b/Source/UI/BetterWorkTabSettingsUI.cs
@@ -33,12 +33,12 @@ namespace Better_Work_Tab.UI
                     drawer.AdvancedLabel = BWTSettingsTranslation.Advanced;
                     drawer.NoResultsLabel = BWTSettingsTranslation.NoResults;
                     drawer.EditColorLabel = BWTSettingsTranslation.Edit;
-                    drawer.ColorPreviewTooltip = "Hover here or adjust the picker to preview this color live on the Work tab.";
+                    drawer.ColorPreviewTooltip = "BWT_Settings_UI_ColorPreviewTooltip".Translate();
                     drawer.ColorPreviewSink = WorkTabColorPreviewController.Instance;
                     drawer.OnSettingPreview = WorkTabColorPreviewController.Instance.PreviewSetting;
                     drawer.Filters = BWTSettingsFilters.Create();
-                    drawer.FilterLabel = "Filter";
-                    drawer.AllSettingsFilterLabel = "All Settings";
+                    drawer.FilterLabel = "BWT_Settings_UI_Filter".Translate();
+                    drawer.AllSettingsFilterLabel = "BWT_Settings_UI_AllSettings".Translate();
                     drawer.IndentPerLevel = 20f;
                     drawer.OnSettingTooltipViewed = MarkSettingViewed;
                     drawer.OnSettingInteracted = (definition, settingsObject) =>

--- a/Source/UI/Chrome/WorkTabChrome.cs
+++ b/Source/UI/Chrome/WorkTabChrome.cs
@@ -137,8 +137,8 @@ namespace Better_Work_Tab.UI.Chrome
 
             TooltipHandler.TipRegion(
                 exitRect,
-                "Back to work types. " + SubWorkDrilldownInput.GestureLabel() +
-                " or press Escape to return.");
+                "BWT_Chrome_BackToWorkTypesTooltip".Translate(
+                    SubWorkDrilldownInput.GestureLabel()));
         }
 
         internal void DrawBottomCounters(Rect inRect, PawnTable table)
@@ -178,14 +178,18 @@ namespace Better_Work_Tab.UI.Chrome
             if (showPawns)
             {
                 GUI.color = new Color(1f, 1f, 1f, 0.7f);
-                Widgets.Label(rect, $"Colonists: {pawnCount}");
+                Widgets.Label(rect, "BWT_Chrome_Colonists".Translate(pawnCount));
             }
 
             // Draw bed count in red if insufficient, otherwise gray.
             if (showBeds)
             {
-                string bedLabel = showPawns ? $" | Beds: {bedCount}" : $"Beds: {bedCount}";
-                float colonistWidth = showPawns ? Text.CalcSize($"Colonists: {pawnCount}").x : 0f;
+                string bedLabel = showPawns
+                    ? " | " + "BWT_Chrome_Beds".Translate(bedCount)
+                    : "BWT_Chrome_Beds".Translate(bedCount);
+                float colonistWidth = showPawns
+                    ? Text.CalcSize("BWT_Chrome_Colonists".Translate(pawnCount)).x
+                    : 0f;
                 Rect bedRect = new Rect(rect.x + colonistWidth, rect.y, rect.width - colonistWidth, rect.height);
 
                 // Red if fewer beds than pawns, gray otherwise.
@@ -220,7 +224,7 @@ namespace Better_Work_Tab.UI.Chrome
             Text.Font = GameFont.Tiny;
             Text.Anchor = TextAnchor.UpperRight;
             GUI.color = new Color(1f, 1f, 1f, 0.42f);
-            Widgets.Label(hintRect, "Alt + click anywhere for settings");
+            Widgets.Label(hintRect, "BWT_Chrome_AltClickSettings".Translate());
             GUI.color = Color.white;
             Text.Anchor = TextAnchor.UpperLeft;
             Text.Font = GameFont.Small;
@@ -290,7 +294,7 @@ namespace Better_Work_Tab.UI.Chrome
             GUI.color = Color.white;
             TooltipHandler.TipRegion(
                 checkboxRect,
-                "This preview changes the global manual-priority mode.");
+                "BWT_Chrome_ManualPriorityPreviewWarning".Translate());
         }
 
         private void DrawPriorityLegend(Rect rect)

--- a/Source/UI/Dialog_ChangePawnTitle.cs
+++ b/Source/UI/Dialog_ChangePawnTitle.cs
@@ -37,13 +37,16 @@ namespace Better_Work_Tab.UI
                 Event.current.Use();
             }
 
-            Widgets.Label(new Rect(0f, 0f, inRect.width, 24f), "Change pawn title");
+            Widgets.Label(new Rect(0f, 0f, inRect.width, 24f), "BWT_Dialog_PawnTitle_Title".Translate());
 
             string defaultTitle = PawnTitleUtility.GetDefaultTitle(pawn);
             string currentTitle = PawnTitleUtility.GetCurrentTitle(pawn);
             Widgets.Label(
                 new Rect(0f, 28f, inRect.width, 24f),
-                "Default: " + (string.IsNullOrEmpty(defaultTitle) ? "(none)" : defaultTitle));
+                "BWT_Dialog_PawnTitle_Default".Translate(
+                    string.IsNullOrEmpty(defaultTitle)
+                        ? "BWT_Dialog_None".Translate()
+                        : defaultTitle));
 
             Rect titleRect = new Rect(0f, 58f, inRect.width, 32f);
             GUI.SetNextControlName("BWTChangePawnTitle");
@@ -63,7 +66,7 @@ namespace Better_Work_Tab.UI
             }
 
             Text.Font = GameFont.Tiny;
-            Widgets.Label(new Rect(0f, 96f, inRect.width, 22f), "Leave blank to use the default title.");
+            Widgets.Label(new Rect(0f, 96f, inRect.width, 22f), "BWT_Dialog_PawnTitle_BlankUsesDefault".Translate());
             Text.Font = GameFont.Small;
 
             // Three equal buttons measured from the actual width, rather than
@@ -78,7 +81,7 @@ namespace Better_Work_Tab.UI
             Rect cancelRect = new Rect(buttonWidth + buttonGap, buttonY, buttonWidth, buttonHeight);
             Rect okRect = new Rect(inRect.width - buttonWidth, buttonY, buttonWidth, buttonHeight);
 
-            if (Widgets.ButtonText(resetRect, "Use default"))
+            if (Widgets.ButtonText(resetRect, "BWT_Dialog_UseDefault".Translate()))
             {
                 titleBuffer = string.Empty;
                 ApplyTitle();
@@ -86,13 +89,13 @@ namespace Better_Work_Tab.UI
                 return;
             }
 
-            if (Widgets.ButtonText(cancelRect, "Cancel"))
+            if (Widgets.ButtonText(cancelRect, "Cancel".Translate()))
             {
                 Close();
                 return;
             }
 
-            if (Widgets.ButtonText(okRect, "OK") || accept)
+            if (Widgets.ButtonText(okRect, "OK".Translate()) || accept)
             {
                 if ((titleBuffer ?? string.Empty).Trim() == currentTitle)
                 {

--- a/Source/UI/Dialog_EditDivider.cs
+++ b/Source/UI/Dialog_EditDivider.cs
@@ -28,7 +28,7 @@ namespace Better_Work_Tab.UI
         public Dialog_EditDivider(PawnDivider divider)
         {
             _divider = divider;
-            _nameBuffer = divider.DividerName ?? "Divider";
+            _nameBuffer = divider.DividerName ?? "BWT_Dialog_Divider_DefaultName".Translate();
             _currentColor = divider.DividerColor;
             _showLabel = divider.ShowLabel;
             _labelFont = divider.LabelFont;
@@ -43,7 +43,7 @@ namespace Better_Work_Tab.UI
         public override void DoWindowContents(Rect inRect)
         {
             Text.Font = GameFont.Small;
-            Widgets.Label(new Rect(0f, 0f, inRect.width, 24f), "Edit divider");
+            Widgets.Label(new Rect(0f, 0f, inRect.width, 24f), "BWT_Dialog_Divider_Title".Translate());
 
             GUI.SetNextControlName("DividerRename");
             _nameBuffer = Widgets.TextField(new Rect(0f, 28f, inRect.width, 32f), _nameBuffer ?? string.Empty);
@@ -63,7 +63,7 @@ namespace Better_Work_Tab.UI
                 SettingIDs.DividersCustomColors,
                 BetterWorkTabMod.Settings?.allowCustomDividerColors ?? DefaultSettings.allowCustomDividerColors))
             {
-                if (Widgets.ButtonText(colorButtonRect, "Divider Color"))
+                if (Widgets.ButtonText(colorButtonRect, "BWT_Dialog_Divider_Color".Translate()))
                 {
                     Find.WindowStack.Add(new Dialog_ColourPicker(_currentColor, (picked, closing) =>
                     {
@@ -74,17 +74,17 @@ namespace Better_Work_Tab.UI
             else
             {
                 GUI.color = Color.gray;
-                Widgets.ButtonText(colorButtonRect, "Divider Color (Disabled)");
+                Widgets.ButtonText(colorButtonRect, "BWT_Dialog_Divider_ColorDisabled".Translate());
                 GUI.color = Color.white;
             }
 
             float optionsTop = colorButtonRect.yMax + 14f;
             Rect showLabelRect = new Rect(0f, optionsTop, inRect.width, 30f);
-            Widgets.CheckboxLabeled(showLabelRect, "Show label", ref _showLabel);
+            Widgets.CheckboxLabeled(showLabelRect, "BWT_Dialog_Divider_ShowLabel".Translate(), ref _showLabel);
 
             Rect fontButtonRect = new Rect(0f, showLabelRect.yMax + 8f, inRect.width, 30f);
             GUI.enabled = _showLabel;
-            if (Widgets.ButtonText(fontButtonRect, $"Text size: {GetFontLabel(_labelFont)}"))
+            if (Widgets.ButtonText(fontButtonRect, "BWT_Dialog_Divider_TextSize".Translate(GetFontLabel(_labelFont))))
             {
                 _labelFont = GetNextFont(_labelFont);
             }
@@ -92,9 +92,17 @@ namespace Better_Work_Tab.UI
 
             float heightBlockTop = fontButtonRect.yMax + 12f;
             var heightLabelRect = new Rect(0f, heightBlockTop, inRect.width, 22f);
-            Widgets.Label(heightLabelRect, $"Height: {_height:F0}px");
+            Widgets.Label(heightLabelRect, "BWT_Dialog_Divider_Height".Translate(_height));
             var heightSliderRect = new Rect(0f, heightLabelRect.yMax + 15f, inRect.width, 27);
-            _height = Widgets.HorizontalSlider(heightSliderRect, _height, 10f, 80f, false, null, "Thin", "Tall");
+            _height = Widgets.HorizontalSlider(
+                heightSliderRect,
+                _height,
+                10f,
+                80f,
+                false,
+                null,
+                "BWT_Dialog_Divider_Thin".Translate(),
+                "BWT_Dialog_Divider_Tall".Translate());
 
             float buttonY = inRect.height - 50f;
             Rect okButton = new Rect(inRect.width - 170f, buttonY, 70f, 30f);
@@ -155,11 +163,11 @@ namespace Better_Work_Tab.UI
             switch (font)
             {
                 case GameFont.Tiny:
-                    return "Tiny";
+                    return "BWT_Dialog_Font_Tiny".Translate();
                 case GameFont.Small:
-                    return "Small";
+                    return "BWT_Dialog_Font_Small".Translate();
                 case GameFont.Medium:
-                    return "Medium";
+                    return "BWT_Dialog_Font_Medium".Translate();
                 default:
                     return font.ToString();
             }

--- a/Source/UI/Dialog_NameNewWorklist.cs
+++ b/Source/UI/Dialog_NameNewWorklist.cs
@@ -26,7 +26,7 @@ namespace Better_Work_Tab.UI
         {
             GUI.BeginGroup(rect);
             float curY = 0f;
-            Widgets.Label(new Rect(0f, curY, rect.width, 35f), "Name new workload");
+            Widgets.Label(new Rect(0f, curY, rect.width, 35f), "BWT_Dialog_Workload_NameTitle".Translate());
             curY += 35f;
 
             string tempName = curName;
@@ -34,7 +34,7 @@ namespace Better_Work_Tab.UI
             curName = tempName;
             curY += 45f;
 
-            if (Widgets.ButtonText(new Rect((rect.width - 120f) / 2f, curY, 120f, 40f), "Accept"))
+            if (Widgets.ButtonText(new Rect((rect.width - 120f) / 2f, curY, 120f, 40f), "BWT_Dialog_Accept".Translate()))
             {
                 workload.RenamableLabel = curName;
                 Close();

--- a/Source/UI/Dialog_RenameGeneric.cs
+++ b/Source/UI/Dialog_RenameGeneric.cs
@@ -62,7 +62,7 @@ namespace Better_Work_Tab.UI
                 _focusedRenameField = true;
             }
 
-            if (Widgets.ButtonText(new Rect(15f, inRect.height - 35f - 10f, inRect.width - 30f, 35f), "OK") || enterPressed)
+            if (Widgets.ButtonText(new Rect(15f, inRect.height - 35f - 10f, inRect.width - 30f, 35f), "OK".Translate()) || enterPressed)
             {
                 if (_currentName.Length == 0)
                 {

--- a/Source/UI/HeaderButtons.cs
+++ b/Source/UI/HeaderButtons.cs
@@ -687,7 +687,9 @@ namespace Better_Work_Tab.UI
             if (DrawFluffyTopButton(
                     rects.Priority,
                     prioritiesEnabled ? FluffyWorkTabIcon.PrioritiesDetailed : FluffyWorkTabIcon.PrioritiesSimple,
-                    prioritiesEnabled ? "Manual priorities" : "Simple priorities",
+                    prioritiesEnabled
+                        ? "BWT_Header_ManualPriorities".Translate().ToString()
+                        : "BWT_Header_SimplePriorities".Translate().ToString(),
                     prioritiesEnabled ? "1" : "Y"))
             {
                 ToggleManualPriorities(!prioritiesEnabled);
@@ -697,7 +699,9 @@ namespace Better_Work_Tab.UI
             if (DrawFluffyTopButton(
                     rects.Scheduler,
                     plannerVisible ? FluffyWorkTabIcon.PrioritiesTimed : FluffyWorkTabIcon.PrioritiesWholeDay,
-                    plannerVisible ? "Close time priorities" : "Open time priorities",
+                    plannerVisible
+                        ? "BWT_Header_CloseHourlyPriorities".Translate().ToString()
+                        : "BWT_Header_OpenHourlyPriorities".Translate().ToString(),
                     plannerVisible ? "T" : "D"))
             {
                 if (!ToggleScheduler(layout))
@@ -710,7 +714,9 @@ namespace Better_Work_Tab.UI
             if (DrawFluffyTopButton(
                     rects.Expand,
                     anyExpanded ? FluffyWorkTabIcon.Collapse : FluffyWorkTabIcon.Expand,
-                    anyExpanded ? "Collapse all specific jobs" : "Expand all specific jobs",
+                    anyExpanded
+                        ? "BWT_Header_CollapseSpecificJobs".Translate().ToString()
+                        : "BWT_Header_ExpandSpecificJobs".Translate().ToString(),
                     anyExpanded ? "-" : "+"))
             {
                 ToggleAllVisibleSubWork(layout);
@@ -970,7 +976,7 @@ namespace Better_Work_Tab.UI
                 : hasWorkload
                     ? (legacyMode
                         ? "BWT_BottomBar_WorkloadTooltip".Translate(name)
-                        : "Open a non-destructive Workload 2.0 preview for " + name + ".")
+                        : "BWT_Workload_OpenPreviewTooltip".Translate(name))
                     : "BWT_BottomBar_WorkloadTooltipEmpty".Translate();
 
             if (DrawWorkloadMainControl(
@@ -993,7 +999,7 @@ namespace Better_Work_Tab.UI
                     if (preview == null)
                     {
                         Messages.Message(
-                            "Modern workload preview is unavailable.",
+                            "BWT_Workload_PreviewUnavailable".Translate(),
                             MessageTypeDefOf.RejectInput,
                             false);
                     }
@@ -1008,7 +1014,7 @@ namespace Better_Work_Tab.UI
                 else
                 {
                     ReportWorkloadFailure(
-                        "Select a workload with the ... menu before opening a preview.");
+                        "BWT_Workload_SelectBeforePreview".Translate());
                 }
             }
 
@@ -1046,7 +1052,7 @@ namespace Better_Work_Tab.UI
                     DrawWorkloadPreviewButton(
                         ToWorkloadActionGroup(rects.WorkloadSaveAsDraw, rects.WorkloadActionClip),
                         ToWorkloadActionGroup(rects.WorkloadSaveAs, rects.WorkloadActionClip),
-                        "Save As",
+                        "BWT_Workload_SaveAs".Translate(),
                         () => QueuePreviewLifecycleAction(
                             preview,
                             BeginWorkloadPreviewSaveAsEditor,
@@ -1054,15 +1060,14 @@ namespace Better_Work_Tab.UI
                         interactive && preview.CanForkPreview,
                         preview.CommitBlockedMessage.AnyNonWhitespace()
                             ? preview.CommitBlockedMessage
-                            : "Save As creates a new workload definition without changing the colony. " +
-                              "Hover to inspect the template changes. Scroll here to move the Work tab.");
+                            : "BWT_Workload_SaveAsTooltip".Translate());
                 }
                 if (rects.HasWorkloadUpdate)
                 {
                     DrawWorkloadPreviewButton(
                         ToWorkloadActionGroup(rects.WorkloadUpdateDraw, rects.WorkloadActionClip),
                         ToWorkloadActionGroup(rects.WorkloadUpdate, rects.WorkloadActionClip),
-                        "Save",
+                        "BWT_Workload_Save".Translate(),
                         () => QueuePreviewLifecycleAction(
                             preview,
                             () => preview.UpdatePreview(),
@@ -1070,14 +1075,13 @@ namespace Better_Work_Tab.UI
                         interactive && preview.CanUpdatePreview,
                         preview.CommitBlockedMessage.AnyNonWhitespace()
                             ? preview.CommitBlockedMessage
-                            : "Save applies this semantic diff and replaces the same workload template. " +
-                              "Hover to inspect changed pawn/worktype cells. Scroll here to move the Work tab.");
+                            : "BWT_Workload_SaveTooltip".Translate());
                 }
 
                 DrawWorkloadPreviewButton(
                     ToWorkloadActionGroup(rects.WorkloadCancelDraw, rects.WorkloadActionClip),
                     ToWorkloadActionGroup(rects.WorkloadCancel, rects.WorkloadActionClip),
-                    PreviewActionLabel(rects.WorkloadCancelDraw, "Cancel", "C"),
+                    PreviewActionLabel(rects.WorkloadCancelDraw, "BWT_Workload_Cancel".Translate(), "C"),
                     () => QueuePreviewLifecycleAction(
                         preview,
                         () => preview.CancelPreview(),
@@ -1085,11 +1089,11 @@ namespace Better_Work_Tab.UI
                     enabled: interactive && preview.CanCancelPreview,
                     tooltip: preview.IsMultiplayerCommitInFlight
                         ? preview.MultiplayerStatusExplanation
-                        : "Cancel the preview and keep live work priorities unchanged.");
+                        : "BWT_Workload_CancelTooltip".Translate());
                 DrawWorkloadPreviewButton(
                     ToWorkloadActionGroup(rects.WorkloadApplyDraw, rects.WorkloadActionClip),
                     ToWorkloadActionGroup(rects.WorkloadApply, rects.WorkloadActionClip),
-                    PreviewActionLabel(rects.WorkloadApplyDraw, "Apply", "A"),
+                    PreviewActionLabel(rects.WorkloadApplyDraw, "BWT_Workload_Apply".Translate(), "A"),
                     () => QueuePreviewLifecycleAction(
                         preview,
                         () => preview.ApplyPreview(),
@@ -1351,7 +1355,7 @@ namespace Better_Work_Tab.UI
 
             if (workloads.Count == 0)
             {
-                options.Add(new FloatMenuOption("No saved workloads.", null));
+                options.Add(new FloatMenuOption("BWT_Workload_NoSaved".Translate(), null));
             }
             else
             {
@@ -1373,13 +1377,13 @@ namespace Better_Work_Tab.UI
             }
 
             options.Add(new FloatMenuOption(
-                "New workload",
+                "BWT_Workload_New".Translate(),
                 () => BeginWorkloadFooterEditor(createNew: true)));
             if (!currentId.NullOrEmpty())
             {
                 string stableId = currentId;
                 options.Add(new FloatMenuOption(
-                    "Workload actions",
+                    "BWT_Workload_Actions".Translate(),
                     () => OpenWorkloadManagementMenu(stableId)));
             }
 
@@ -1398,12 +1402,12 @@ namespace Better_Work_Tab.UI
                 var options = new List<FloatMenuOption>
                 {
                     new FloatMenuOption(
-                        "Rename",
+                        "BWT_Workload_Rename".Translate(),
                         () => BeginWorkloadFooterEditor(
                             createNew: false,
                             stableId: stableId)),
                     new FloatMenuOption(
-                        "Delete",
+                        "BWT_Workload_Delete".Translate(),
                         () => DeleteWorkloadInline(stableId))
                 };
                 Find.WindowStack.Add(new FloatMenu(options));
@@ -1524,10 +1528,10 @@ namespace Better_Work_Tab.UI
             Widgets.Label(
                 new Rect(panel.xMin + 8f, panel.yMin + 5f, panel.width - 16f, 20f),
                 _workloadFooterEditSaveAs
-                    ? "Save workload as"
+                    ? "BWT_Workload_SaveAsTitle".Translate().ToString()
                     : _workloadFooterEditCreatesNew
-                        ? "New workload"
-                        : "Rename workload");
+                        ? "BWT_Workload_NewTitle".Translate().ToString()
+                        : "BWT_Workload_RenameTitle".Translate().ToString());
             _workloadFooterEditFieldRect = new Rect(
                 panel.xMin + 8f,
                 panel.yMin + 30f,
@@ -1552,11 +1556,13 @@ namespace Better_Work_Tab.UI
                 24f);
             DrawWorkloadFooterButton(
                 _workloadFooterEditConfirmRect,
-                _workloadFooterEditSaveAs ? "Save As" : "Save",
+                _workloadFooterEditSaveAs
+                    ? "BWT_Workload_SaveAs".Translate().ToString()
+                    : "BWT_Workload_Save".Translate().ToString(),
                 CommitWorkloadFooterEditor);
             DrawWorkloadFooterButton(
                 _workloadFooterEditCancelRect,
-                "Cancel",
+                "BWT_Workload_Cancel".Translate(),
                 CloseWorkloadFooterPopover);
 
             Event evt = Event.current;
@@ -1581,11 +1587,11 @@ namespace Better_Work_Tab.UI
         {
             Widgets.Label(
                 new Rect(panel.xMin + 8f, panel.yMin + 5f, panel.width - 16f, 20f),
-                "Apply legacy workload?");
+                "BWT_Workload_ApplyLegacyTitle".Translate());
             GUI.color = new Color(0.78f, 0.86f, 0.87f, 0.95f);
             Widgets.Label(
                 new Rect(panel.xMin + 8f, panel.yMin + 28f, panel.width - 16f, 32f),
-                "Applying this will reset the current work tab priority configuration. Continue?");
+                "BWT_Workload_ApplyLegacyBody".Translate());
             GUI.color = Color.white;
             Widgets.CheckboxLabeled(
                 new Rect(panel.xMin + 8f, panel.yMin + 62f, panel.width - 16f, 20f),
@@ -1605,11 +1611,11 @@ namespace Better_Work_Tab.UI
                 24f);
             DrawWorkloadFooterButton(
                 _workloadFooterConfirmApplyRect,
-                "Apply",
+                "BWT_Workload_Apply".Translate(),
                 ConfirmLegacyWorkloadApply);
             DrawWorkloadFooterButton(
                 _workloadFooterConfirmCancelRect,
-                "Cancel",
+                "BWT_Workload_Cancel".Translate(),
                 CloseWorkloadFooterPopover);
         }
 
@@ -1668,7 +1674,7 @@ namespace Better_Work_Tab.UI
                 string candidate;
                 do
                 {
-                    candidate = "Workload " + number++;
+                    candidate = "BWT_Workload_DefaultName".Translate(number++);
                 }
                 while (ContainsWorkloadLabel(workloads, candidate));
 
@@ -1692,7 +1698,7 @@ namespace Better_Work_Tab.UI
             _workloadFooterEditCreatesNew = false;
             _workloadFooterEditSaveAs = true;
             _workloadFooterEditStableId = preview.SourceStableId;
-            _workloadFooterEditBuffer = preview.SourceLabel + " copy";
+            _workloadFooterEditBuffer = "BWT_Workload_CopyName".Translate(preview.SourceLabel);
             return true;
         }
 
@@ -1701,7 +1707,7 @@ namespace Better_Work_Tab.UI
             string label = (_workloadFooterEditBuffer ?? string.Empty).Trim();
             if (label.Length == 0)
             {
-                ReportWorkloadFailure("A workload name is required.");
+                ReportWorkloadFailure("BWT_Workload_NameRequired".Translate());
                 return;
             }
 
@@ -1710,7 +1716,7 @@ namespace Better_Work_Tab.UI
             {
                 if (preview == null || !preview.IsActive)
                 {
-                    ReportWorkloadFailure("The workload preview is no longer active.");
+                    ReportWorkloadFailure("BWT_Workload_PreviewEnded".Translate());
                     return;
                 }
 
@@ -1886,7 +1892,7 @@ namespace Better_Work_Tab.UI
         {
             if (!message.AnyNonWhitespace())
             {
-                message = "The workload operation could not be completed.";
+                message = "BWT_Workload_OperationFailed".Translate();
             }
 
             Messages.Message(message, MessageTypeDefOf.RejectInput, false);

--- a/Source/UI/RuleBuilder/Panels/RuleEditorPanel.cs
+++ b/Source/UI/RuleBuilder/Panels/RuleEditorPanel.cs
@@ -516,10 +516,10 @@ namespace Better_Work_Tab.UI.RuleBuilder.Panels
             }
 
             GUI.color = RuleBuilderConstants.SubtleTextColor;
-            Verse.Widgets.Label(hintRect, $"0-{maxPriority}  (mouse wheel adjusts by 1)");
+            Verse.Widgets.Label(hintRect, "BWT_PriorityInput_RangeHint".Translate(maxPriority));
             GUI.color = Color.white;
 
-            TooltipHandler.TipRegion(fieldRect, $"Priority value from 0 to {maxPriority}. Use the mouse wheel to adjust quickly.");
+            TooltipHandler.TipRegion(fieldRect, "BWT_PriorityInput_RangeTooltip".Translate(maxPriority));
         }
 
         private void DrawConditionEditor(Rect rect, RuleBuilderState state)

--- a/Source/UI/RuleBuilder/Services/RuleDragController.cs
+++ b/Source/UI/RuleBuilder/Services/RuleDragController.cs
@@ -94,14 +94,14 @@ namespace Better_Work_Tab.UI.RuleBuilder.Services
             GUI.color = new Color(0.8f, 0.9f, 1f, isHovered ? 1f : 0.7f);
             // Increased height to 18f and moved up slightly to prevent clipping of descenders
             Rect labelRect = new Rect(rect.x, rect.yMax - 18f, rect.width, 18f);
-            Verse.Widgets.Label(labelRect, "⇄ Drag");
+            Verse.Widgets.Label(labelRect, "BWT_RuleDrag_Handle".Translate());
             Text.Anchor = TextAnchor.UpperLeft;
             GUI.color = Color.white;
             
             // Tooltip
             string tip = "BWT_DragToDuplicate".CanTranslate() 
                 ? "BWT_DragToDuplicate".Translate() 
-                : "Drag to duplicate these rules to another Work Type or Priority";
+                : "Drag to copy these rules to another Work type or priority.";
             TooltipHandler.TipRegion(rect, tip);
             
             // Handle mouse input
@@ -240,9 +240,9 @@ namespace Better_Work_Tab.UI.RuleBuilder.Services
             
             // Determine size based on content
             int rulesCount = DraggedRules.Count;
-            string countText = $"{rulesCount} rule{(rulesCount != 1 ? "s" : "")}";
-            string fromText = SourceWorkType != null 
-                ? $"from {SourceWorkType.labelShort}" 
+            string countText = "BWT_RuleDrag_Count".Translate(rulesCount);
+            string fromText = SourceWorkType != null
+                ? "BWT_RuleDrag_From".Translate(SourceWorkType.labelShort).ToString()
                 : "";
             
             float boxWidth = 180f;
@@ -282,7 +282,7 @@ namespace Better_Work_Tab.UI.RuleBuilder.Services
                 Text.Font = GameFont.Small;
                 Text.Anchor = TextAnchor.MiddleLeft;
                 Rect textRect = new Rect(38f, 6f, innerRect.width - 44f, 20f);
-                Verse.Widgets.Label(textRect, "Duplicating " + countText);
+                Verse.Widgets.Label(textRect, "BWT_RuleDrag_Copying".Translate(countText));
                 
                 // Subtext
                 if (!string.IsNullOrEmpty(fromText))

--- a/Source/UI/RuleBuilder/Widgets/ConditionBuilderWidget.cs
+++ b/Source/UI/RuleBuilder/Widgets/ConditionBuilderWidget.cs
@@ -39,7 +39,7 @@ namespace Better_Work_Tab.UI.RuleBuilder.Widgets
                 case ConditionType.Trait:
                 case ConditionType.Gender:
                 case ConditionType.Xenotype:
-                    Verse.Widgets.Label(valueRect, "Configure via add menu");
+                    Verse.Widgets.Label(valueRect, "BWT_ConfigureFromConditionMenu".Translate());
                     break;
                 default:
                     Verse.Widgets.Label(valueRect, "-");

--- a/Source/UI/RuleBuilder/Widgets/RuleRowWidget.cs
+++ b/Source/UI/RuleBuilder/Widgets/RuleRowWidget.cs
@@ -47,8 +47,8 @@ namespace Better_Work_Tab.UI.RuleBuilder.Widgets
                 Rect upRect = new Rect(deleteRect.x - 26f, deleteRect.y, 24f, 24f);
                 Rect downRect = new Rect(upRect.x - 26f, upRect.y, 24f, 24f);
 
-                if (Verse.Widgets.ButtonText(upRect, "Up")) return RowAction.MoveUp;
-                if (Verse.Widgets.ButtonText(downRect, "Dn")) return RowAction.MoveDown;
+                if (Verse.Widgets.ButtonText(upRect, "BWT_MoveRuleUp".Translate())) return RowAction.MoveUp;
+                if (Verse.Widgets.ButtonText(downRect, "BWT_MoveRuleDown".Translate())) return RowAction.MoveDown;
                 if (Verse.Widgets.ButtonImage(deleteRect, TexButton.Delete, Color.white, GenUI.MouseoverColor))
                     return RowAction.Delete;
             }

--- a/Source/UI/RuleBuilder/Window_PriorityNumberPicker.cs
+++ b/Source/UI/RuleBuilder/Window_PriorityNumberPicker.cs
@@ -212,7 +212,7 @@ namespace Better_Work_Tab.UI.RuleBuilder
                 Close();
             }
 
-            if (RWWidgets.ButtonText(okRect, "OK"))
+            if (RWWidgets.ButtonText(okRect, "BWT_OK".Translate()))
             {
                 ConfirmSelection();
             }

--- a/Source/UI/RuleBuilder/Window_RulesetBuilder.cs
+++ b/Source/UI/RuleBuilder/Window_RulesetBuilder.cs
@@ -129,7 +129,7 @@ namespace Better_Work_Tab.UI.RuleBuilder
             if (_state.SelectedRuleset != null && !_state.SelectedRuleset.IsDefault)
             {
                 Rect editButtonRect = new Rect(newButtonRect.x - 70f - 10f, rect.y + 6f, 70f, 28f);
-                if (RWWidgets.ButtonText(editButtonRect, "Edit"))
+                if (RWWidgets.ButtonText(editButtonRect, "BWT_Edit".Translate()))
                 {
                     OpenRenameDialog(_state.SelectedRuleset);
                 }

--- a/Source/UI/RulesetListDragUI.cs
+++ b/Source/UI/RulesetListDragUI.cs
@@ -305,10 +305,10 @@ namespace Better_Work_Tab.UI
         {
             rect.SplitHorizontally(rect.height * 0.5f, out Rect topBtn, out Rect _);
 
-            if (Widgets.ButtonText(topBtn.LeftPart(0.48f), "New Ruleset"))
+            if (Widgets.ButtonText(topBtn.LeftPart(0.48f), "BWT_NewRuleset".Translate()))
             {
                 var newSet = new WorkAssignmentRuleset(
-                    "New Ruleset " + (_items.Count + 1),
+                    "BWT_NewRuleset".Translate().ToString() + " " + (_items.Count + 1),
                     new List<WorkAssignmentParameters>());
 
                 _items.Add(newSet);
@@ -317,7 +317,7 @@ namespace Better_Work_Tab.UI
             }
 
             if (SelectedRuleset != null &&
-                Widgets.ButtonText(topBtn.RightPart(0.48f), "Duplicate"))
+                Widgets.ButtonText(topBtn.RightPart(0.48f), "BWT_Duplicate".Translate()))
             {
                 var copied = SelectedRuleset.Copy();
                 _items.Add(copied);

--- a/Source/UI/Settings/BWTSettingsContextFocus.cs
+++ b/Source/UI/Settings/BWTSettingsContextFocus.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Spine.UI.SettingsFramework;
+using Verse;
 
 namespace Better_Work_Tab.UI.Settings
 {
@@ -38,7 +39,7 @@ namespace Better_Work_Tab.UI.Settings
                 Id = "context." + SanitizeId(request.Label),
                 Label = request.Label,
                 Category = "context",
-                CategoryLabel = "Context",
+                CategoryLabel = "BWT_Settings_Filter_Context".Translate(),
                 Tooltip = request.Tooltip,
                 Predicate = (def, _) => def != null && !string.IsNullOrEmpty(def.Id) && ids.Contains(def.Id),
                 IncludeChildrenOfMatches = true

--- a/Source/UI/Settings/BWTSettingsFilters.cs
+++ b/Source/UI/Settings/BWTSettingsFilters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Spine.UI.SettingsFramework;
+using Verse;
 using static Better_Work_Tab.UI.Settings.SettingIDs;
 
 namespace Better_Work_Tab.UI.Settings
@@ -60,85 +61,85 @@ namespace Better_Work_Tab.UI.Settings
                 BuildVersionFilter("version.1.1", "BWT v1.1", IsV11Setting),
                 BuildVersionFilter("version.1.0.5", "BWT v1.0.5", IsV105Setting),
                 BuildVersionFilter("version.1.0", "BWT v1.0", IsV10Setting),
-                BuildSystemFilter("system.subwork", "Sub-work Jobs", FeaturesSubWorkJobs),
-                BuildSystemFilter("system.headers", "Headers", HeadersHeader),
-                BuildSystemFilter("system.dividers", "Dividers", FeaturesDividers),
-                BuildSystemFilter("system.dragdrop", "Drag & Drop", FeaturesDragdrop),
-                BuildSystemFilter("system.priorities", "Priorities", PriorityHeader),
-                BuildSystemFilter("system.timePriority", "Time Priority Schedule", UiTimePrioritySchedules),
-                BuildSystemFilter("system.fluffyStyle", "Fluffy-style Work Tab", CompatFluffyWorkTabHeader),
-                BuildSystemFilter("system.workloads", "Workloads", FeaturesWorkloads),
-                BuildSystemFilter("system.rules", "Rulesets", FeaturesAutoassign),
-                BuildSystemFilter("system.highlights", "Highlights", FeaturesHighlights),
-                BuildSystemFilter("system.ui", "UI Display", FeaturesUiElements),
-                BuildSystemFilter("system.clicks", "Clicks & Shortcuts", FeaturesClicks),
+                BuildSystemFilter("system.subwork", "BWT_Settings_Filter_SpecificJobs".Translate(), FeaturesSubWorkJobs),
+                BuildSystemFilter("system.headers", "BWT_Settings_Filter_Headers".Translate(), HeadersHeader),
+                BuildSystemFilter("system.dividers", "BWT_Settings_Filter_Dividers".Translate(), FeaturesDividers),
+                BuildSystemFilter("system.dragdrop", "BWT_Settings_Filter_DragDrop".Translate(), FeaturesDragdrop),
+                BuildSystemFilter("system.priorities", "BWT_Settings_Filter_Priorities".Translate(), PriorityHeader),
+                BuildSystemFilter("system.timePriority", "BWT_Settings_Filter_HourlyPriorities".Translate(), UiTimePrioritySchedules),
+                BuildSystemFilter("system.fluffyStyle", "BWT_Settings_Filter_FluffyStyle".Translate(), CompatFluffyWorkTabHeader),
+                BuildSystemFilter("system.workloads", "BWT_Settings_Filter_Workloads".Translate(), FeaturesWorkloads),
+                BuildSystemFilter("system.rules", "BWT_Settings_Filter_RuleBuilder".Translate(), FeaturesAutoassign),
+                BuildSystemFilter("system.highlights", "BWT_Settings_Filter_Highlights".Translate(), FeaturesHighlights),
+                BuildSystemFilter("system.ui", "BWT_Settings_Filter_Display".Translate(), FeaturesUiElements),
+                BuildSystemFilter("system.clicks", "BWT_Settings_Filter_Controls".Translate(), FeaturesClicks),
                 new SettingsFilterDefinition
                 {
                     Id = "worktab.style",
-                    Label = "Work Tab-style",
+                    Label = "BWT_Settings_Filter_WorkTabStyle".Translate(),
                     Category = PresetsCategory,
-                    CategoryLabel = "Presets",
-                    Tooltip = "Settings that map to common expanded Work tab behavior: compact headers, priorities, sub-work priorities, dividers, dragging, skill overlays, workload presets, and time planning.",
+                    CategoryLabel = "BWT_Settings_Filter_Presets".Translate(),
+                    Tooltip = "BWT_Settings_Filter_WorkTabStyleTooltip".Translate(),
                     Predicate = (def, _) => IsWorkTabStyleSetting(def),
                     IncludeChildrenOfMatches = false
                 },
                 new SettingsFilterDefinition
                 {
                     Id = "vanilla.plus",
-                    Label = "Vanilla+",
+                    Label = "BWT_Settings_Filter_VanillaPlus".Translate(),
                     Category = PresetsCategory,
-                    CategoryLabel = "Presets",
-                    Tooltip = "Low-disruption settings that keep the Work tab close to vanilla while adding polish: headers, drag/reorder, highlights, overlays, counts, priority display, and layout spacing.",
+                    CategoryLabel = "BWT_Settings_Filter_Presets".Translate(),
+                    Tooltip = "BWT_Settings_Filter_VanillaPlusTooltip".Translate(),
                     Predicate = (def, _) => IsVanillaPlusSetting(def),
                     IncludeChildrenOfMatches = false
                 },
                 new SettingsFilterDefinition
                 {
                     Id = "state.enabled",
-                    Label = "Enabled Settings",
+                    Label = "BWT_Settings_Filter_Enabled".Translate(),
                     Category = StatesCategory,
-                    CategoryLabel = "States",
-                    Tooltip = "Only boolean settings that are currently enabled.",
+                    CategoryLabel = "BWT_Settings_Filter_States".Translate(),
+                    Tooltip = "BWT_Settings_Filter_EnabledTooltip".Translate(),
                     Predicate = (def, settings) => TryReadBool(def, settings, out bool value) && value,
                     IncludeChildrenOfMatches = false
                 },
                 new SettingsFilterDefinition
                 {
                     Id = "state.disabled",
-                    Label = "Disabled Settings",
+                    Label = "BWT_Settings_Filter_Disabled".Translate(),
                     Category = StatesCategory,
-                    CategoryLabel = "States",
-                    Tooltip = "Only boolean settings that are currently disabled.",
+                    CategoryLabel = "BWT_Settings_Filter_States".Translate(),
+                    Tooltip = "BWT_Settings_Filter_DisabledTooltip".Translate(),
                     Predicate = (def, settings) => TryReadBool(def, settings, out bool value) && !value,
                     IncludeChildrenOfMatches = false
                 },
                 new SettingsFilterDefinition
                 {
                     Id = "state.changed",
-                    Label = "Changed From Default",
+                    Label = "BWT_Settings_Filter_Changed".Translate(),
                     Category = StatesCategory,
-                    CategoryLabel = "States",
-                    Tooltip = "Only settings whose current value differs from the registered default.",
+                    CategoryLabel = "BWT_Settings_Filter_States".Translate(),
+                    Tooltip = "BWT_Settings_Filter_ChangedTooltip".Translate(),
                     Predicate = IsChangedFromDefault,
                     IncludeChildrenOfMatches = false
                 },
                 new SettingsFilterDefinition
                 {
                     Id = "state.notViewed",
-                    Label = "Not Yet Viewed",
+                    Label = "BWT_Settings_Filter_NotViewed".Translate(),
                     Category = StatesCategory,
-                    CategoryLabel = "States",
-                    Tooltip = "Settings whose tooltip has not been opened yet.",
+                    CategoryLabel = "BWT_Settings_Filter_States".Translate(),
+                    Tooltip = "BWT_Settings_Filter_NotViewedTooltip".Translate(),
                     Predicate = IsNotYetViewed,
                     IncludeChildrenOfMatches = false
                 },
                 new SettingsFilterDefinition
                 {
                     Id = "system.animations",
-                    Label = "Animations",
+                    Label = "BWT_Settings_Filter_Animations".Translate(),
                     Category = SystemsCategory,
-                    CategoryLabel = "Systems",
-                    Tooltip = "Animation and cursor movement settings.",
+                    CategoryLabel = "BWT_Settings_Filter_Systems".Translate(),
+                    Tooltip = "BWT_Settings_Filter_AnimationsTooltip".Translate(),
                     Predicate = (def, _) => ContainsAny(def, "animation", "animate", "cursor"),
                     IncludeChildrenOfMatches = true
                 }
@@ -152,8 +153,8 @@ namespace Better_Work_Tab.UI.Settings
                 Id = id,
                 Label = label,
                 Category = SystemsCategory,
-                CategoryLabel = "Systems",
-                Tooltip = $"Show settings under {label}.",
+                CategoryLabel = "BWT_Settings_Filter_Systems".Translate(),
+                Tooltip = "BWT_Settings_Filter_SystemTooltip".Translate(label),
                 Predicate = (def, _) => string.Equals(def.Id, rootId, StringComparison.OrdinalIgnoreCase),
                 IncludeChildrenOfMatches = true
             };
@@ -169,8 +170,8 @@ namespace Better_Work_Tab.UI.Settings
                 Id = id,
                 Label = label,
                 Category = VersionsCategory,
-                CategoryLabel = "Versions",
-                Tooltip = "Show settings added or materially changed in this BWT version.",
+                CategoryLabel = "BWT_Settings_Filter_Versions".Translate(),
+                Tooltip = "BWT_Settings_Filter_VersionTooltip".Translate(),
                 Predicate = (def, _) => predicate(def),
                 IncludeChildrenOfMatches = true
             };

--- a/Source/UI/Settings/BWTSettingsImportExportActions.cs
+++ b/Source/UI/Settings/BWTSettingsImportExportActions.cs
@@ -18,11 +18,11 @@ namespace Better_Work_Tab.UI.Settings
         {
             return new SettingsImportExportActions
             {
-                ExportLabel = "Export",
-                ImportLabel = "Import",
-                FileLabel = "File",
-                ClipboardLabel = "Clipboard",
-                CancelLabel = "Cancel",
+                ExportLabel = "BWT_Settings_ImportExport_Export".Translate(),
+                ImportLabel = "BWT_Settings_ImportExport_Import".Translate(),
+                FileLabel = "BWT_Settings_ImportExport_File".Translate(),
+                ClipboardLabel = "BWT_Settings_ImportExport_Clipboard".Translate(),
+                CancelLabel = "Cancel".Translate(),
                 ExportToClipboard = () => ExportToClipboard(settings),
                 ExportToFile = () => ShowExportPathDialog(settings),
                 ImportFromClipboard = () => ConfirmImport(() => ImportFromClipboard(settings, afterImport)),
@@ -35,21 +35,21 @@ namespace Better_Work_Tab.UI.Settings
             try
             {
                 GUIUtility.systemCopyBuffer = BWTSettingsJsonService.Export(settings);
-                Messages.Message("All Better Work Tab settings data copied to clipboard.", MessageTypeDefOf.PositiveEvent, false);
+                Messages.Message("BWT_Settings_ImportExport_Copied".Translate(), MessageTypeDefOf.PositiveEvent, false);
             }
             catch (Exception ex)
             {
                 Log.Error($"[Better Work Tab] Failed to export settings to the clipboard: {ex}");
-                Messages.Message("Failed to export Better Work Tab settings. Check the log for details.", MessageTypeDefOf.RejectInput, false);
+                Messages.Message("BWT_Settings_ImportExport_ExportFailed".Translate(), MessageTypeDefOf.RejectInput, false);
             }
         }
 
         private static void ShowExportPathDialog(BetterWorkTabSettings settings)
         {
             Find.WindowStack.Add(new Dialog_BWTSettingsJsonPath(
-                "Export All Better Work Tab Settings Data",
+                "BWT_Settings_ImportExport_ExportTitle".Translate(),
                 DefaultPath,
-                "Export",
+                "BWT_Settings_ImportExport_Export".Translate(),
                 path =>
                 {
                     try
@@ -61,12 +61,12 @@ namespace Better_Work_Tab.UI.Settings
                         }
 
                         File.WriteAllText(path, BWTSettingsJsonService.Export(settings));
-                        Messages.Message($"All Better Work Tab settings data exported to {path}.", MessageTypeDefOf.PositiveEvent, false);
+                        Messages.Message("BWT_Settings_ImportExport_Exported".Translate(path), MessageTypeDefOf.PositiveEvent, false);
                     }
                     catch (Exception ex)
                     {
                         Log.Error($"[Better Work Tab] Failed to export settings to {path}: {ex}");
-                        Messages.Message("Failed to export Better Work Tab settings. Check the log for details.", MessageTypeDefOf.RejectInput, false);
+                        Messages.Message("BWT_Settings_ImportExport_ExportFailed".Translate(), MessageTypeDefOf.RejectInput, false);
                     }
                 }));
         }
@@ -79,16 +79,16 @@ namespace Better_Work_Tab.UI.Settings
         private static void ShowImportPathDialog(BetterWorkTabSettings settings, Action afterImport)
         {
             Find.WindowStack.Add(new Dialog_BWTSettingsJsonPath(
-                "Import Better Work Tab Settings",
+                "BWT_Settings_ImportExport_ImportTitle".Translate(),
                 DefaultPath,
-                "Import",
+                "BWT_Settings_ImportExport_Import".Translate(),
                 path =>
                 {
                     try
                     {
                         if (!File.Exists(path))
                         {
-                            Messages.Message("That Better Work Tab settings file does not exist.", MessageTypeDefOf.RejectInput, false);
+                            Messages.Message("BWT_Settings_ImportExport_FileMissing".Translate(), MessageTypeDefOf.RejectInput, false);
                             return;
                         }
 
@@ -97,7 +97,7 @@ namespace Better_Work_Tab.UI.Settings
                     catch (Exception ex)
                     {
                         Log.Error($"[Better Work Tab] Failed to import settings from {path}: {ex}");
-                        Messages.Message("Failed to import Better Work Tab settings. Check the log for details.", MessageTypeDefOf.RejectInput, false);
+                        Messages.Message("BWT_Settings_ImportExport_ImportFailed".Translate(), MessageTypeDefOf.RejectInput, false);
                     }
                 }));
         }
@@ -117,10 +117,10 @@ namespace Better_Work_Tab.UI.Settings
         private static void ConfirmImport(Action action)
         {
             Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
-                "Importing will overwrite all Better Work Tab settings data, including rulesets, layout state, viewed-setting history, and recent colors. Continue?",
+                "BWT_Settings_ImportExport_ConfirmImport".Translate(),
                 action,
                 destructive: true,
-                title: "Import Better Work Tab Settings"));
+                title: "BWT_Settings_ImportExport_ImportTitle".Translate()));
         }
 
         private static string DefaultPath => Path.Combine(GenFilePaths.ConfigFolderPath, DefaultFileName);

--- a/Source/UI/Settings/BWTSettingsRegistry.cs
+++ b/Source/UI/Settings/BWTSettingsRegistry.cs
@@ -353,7 +353,7 @@ namespace Better_Work_Tab.UI.Settings
 
             if (Widgets.ButtonText(buttonRect, GetSubWorkTransitionModeLabel(settings)))
             {
-                var offOption = new FloatMenuOption("Off (instant)", () =>
+                var offOption = new FloatMenuOption("BWT_SubWorkTransition_Off".Translate(), () =>
                     {
                         settings.enableSubWorkTransitionAnimation = false;
                         HeaderDrawingCoordinator.NotifyAngledHeadersChanged();
@@ -387,9 +387,9 @@ namespace Better_Work_Tab.UI.Settings
                         : classicOption;
                 var optionDescriptions = new Dictionary<FloatMenuOption, string>
                 {
-                    [offOption] = "Turns the specific-job transition animation off. Columns change immediately when entering or leaving the specific-job view.",
-                    [classicOption] = "Uses BWT's original transition: columns glide into position with a brief flash while entering or leaving the specific-job view.",
-                    [pixelOption] = "Keeps the columns in place while a grey pixel wave passes across them, progressively revealing or hiding the specific-job view."
+                    [offOption] = "BWT_SubWorkTransition_Off_Description".Translate(),
+                    [classicOption] = "BWT_Enum_SubWorkTransitionStyle_ClassicGlideFlash_Description".Translate(),
+                    [pixelOption] = "BWT_Enum_SubWorkTransitionStyle_PixelWaveFlip_Description".Translate()
                 };
                 Find.WindowStack.Add(new DescribedFloatMenu(options, selectedOption, label, tooltip, optionDescriptions));
             }
@@ -409,7 +409,7 @@ namespace Better_Work_Tab.UI.Settings
         {
             if (settings == null || !settings.enableSubWorkTransitionAnimation)
             {
-                return "Off (instant)";
+                return "BWT_SubWorkTransition_Off".Translate();
             }
 
             return GetSubWorkTransitionStyleLabel(settings.subWorkTransitionStyle);
@@ -858,7 +858,7 @@ namespace Better_Work_Tab.UI.Settings
                          s.Color_FloatMenuHighlight = picked;
                          s.Color_CustomSimilarWorktypeHighlight = picked;
                          s.Write();
-                         Messages.Message("Master color applied to all highlight settings.", MessageTypeDefOf.PositiveEvent, false);
+                         Messages.Message("BWT_Settings_MasterHighlightColor_Applied".Translate(), MessageTypeDefOf.PositiveEvent, false);
                      }));
                 }
             }
@@ -1155,7 +1155,7 @@ namespace Better_Work_Tab.UI.Settings
                             div.Height = settings.dividerHeight;
                         }
                         MainTabWindowUtility.NotifyAllPawnTables_PawnsChanged();
-                        Messages.Message("Dividers reset to default height.", MessageTypeDefOf.PositiveEvent, false);
+                        Messages.Message("BWT_Settings_DividerHeight_Reset".Translate(), MessageTypeDefOf.PositiveEvent, false);
                     }
                 }
             }
@@ -1674,7 +1674,7 @@ namespace Better_Work_Tab.UI.Settings
                         return;
                     }
 
-                    Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation("Restore every Better Work Tab setting to its default? Your current settings will be lost.", () =>
+                    Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation("BWT_Settings_RestoreDefaults_Confirm".Translate(), () =>
                     {
                         if (BWTWorkloadSettingsOwnershipPolicy.IsBulkSettingsOperationBlocked(out string confirmationBlockReason))
                         {
@@ -1685,8 +1685,8 @@ namespace Better_Work_Tab.UI.Settings
                         settings.RestoreDefaults();
                         WorkColumnOrderManager.ResetToVanilla();
                         settings.Write();
-                        Messages.Message("Factory defaults restored.", MessageTypeDefOf.PositiveEvent, false);
-                    }, true, "Confirm Restore"));
+                        Messages.Message("BWT_Settings_RestoreDefaults_Done".Translate(), MessageTypeDefOf.PositiveEvent, false);
+                    }, true, "BWT_Settings_RestoreDefaults_Title".Translate()));
                 }
             }
             )

--- a/Source/UI/Settings/BWTSettingsSearchRuntime.cs
+++ b/Source/UI/Settings/BWTSettingsSearchRuntime.cs
@@ -201,10 +201,10 @@ namespace Better_Work_Tab.UI.Settings
             }
 
             string first = string.IsNullOrEmpty(notice.FirstLabel)
-                ? "an Advanced setting"
+                ? "BWT_Settings_Search_AdvancedSetting".Translate()
                 : notice.FirstLabel;
             string suffix = notice.MatchCount > 1
-                ? " (" + notice.MatchCount + " matches)"
+                ? "BWT_Settings_Search_MatchCount".Translate(notice.MatchCount)
                 : string.Empty;
             string label = string.Format(
                 BWTSettingsTranslation.AdvancedSearchNotice,
@@ -216,9 +216,8 @@ namespace Better_Work_Tab.UI.Settings
                 Mathf.Min(AdvancedNoticeHeight, rect.height));
             bool clicked = Widgets.ButtonText(buttonRect, label);
             string tooltip = string.IsNullOrEmpty(notice.Context)
-                ? "This result is hidden in Simple view. Switch to Advanced to reveal it."
-                : "Advanced setting context: " + notice.Context +
-                ". Switch to Advanced to reveal it.";
+                ? "BWT_Settings_Search_HiddenInSimple".Translate()
+                : "BWT_Settings_Search_AdvancedContext".Translate(notice.Context);
             TooltipHandler.TipRegion(buttonRect, tooltip);
             return clicked;
         }
@@ -256,14 +255,14 @@ namespace Better_Work_Tab.UI.Settings
                 rect.height);
             Widgets.Label(labelRect, label ?? string.Empty);
             string status = ActiveAliasCount == 0 && PendingAliasCount == 0
-                ? "None"
-                : ActiveAliasCount + " active, " + PendingAliasCount + " pending";
+                ? "BWT_Settings_Search_None".Translate()
+                : "BWT_Settings_Search_AliasStatus".Translate(ActiveAliasCount, PendingAliasCount);
             TextAnchor oldAnchor = Text.Anchor;
             Text.Anchor = TextAnchor.MiddleRight;
             Widgets.Label(valueRect, status);
             Text.Anchor = oldAnchor;
 
-            bool clicked = !disabled && Widgets.ButtonText(buttonRect, "Reset");
+            bool clicked = !disabled && Widgets.ButtonText(buttonRect, "BWT_Settings_Search_Reset".Translate());
             if (clicked)
             {
                 Reset();
@@ -271,9 +270,9 @@ namespace Better_Work_Tab.UI.Settings
 
             if (!string.IsNullOrEmpty(tooltip))
             {
-                TooltipHandler.TipRegion(rect, tooltip +
-                    " Three deliberate corrections are required before a local alias is used. " +
-                    "No query text leaves this computer.");
+                TooltipHandler.TipRegion(
+                    rect,
+                    tooltip + " " + "BWT_Settings_Search_AliasPrivacy".Translate());
             }
 
             GUI.color = oldColor;

--- a/Source/UI/Settings/BWTSettingsTranslation.cs
+++ b/Source/UI/Settings/BWTSettingsTranslation.cs
@@ -34,7 +34,7 @@ namespace Better_Work_Tab.UI.Settings
                 const string key = "BWT_Settings_UI_AdvancedSearchNotice";
                 return key.CanTranslate()
                     ? key.Translate()
-                    : "Found in Advanced settings: {0} — click to switch to Advanced";
+                    : "Found in Advanced settings: {0}. Click to switch to Advanced.";
             }
         }
 

--- a/Source/UI/Settings/BWTWorkTabContextSettingsRouter.cs
+++ b/Source/UI/Settings/BWTWorkTabContextSettingsRouter.cs
@@ -1084,7 +1084,7 @@ namespace Better_Work_Tab.UI.Settings
                 _lastObservedLegacyMode = previousLegacy;
                 _lastObservedLegacyModeValid = true;
                 Messages.Message(
-                    "Workload mode cannot be changed while a workload preview is active. Close the preview first.",
+                    "BWT_Settings_WorkloadMode_PreviewBlocked".Translate(),
                     MessageTypeDefOf.RejectInput,
                     false);
                 return;
@@ -1110,7 +1110,7 @@ namespace Better_Work_Tab.UI.Settings
             _lastObservedLegacyModeValid = true;
             Messages.Message(
                 string.IsNullOrEmpty(result.Message)
-                    ? "The workload mode could not be changed safely."
+                    ? "BWT_Settings_WorkloadMode_ChangeFailed".Translate().ToString()
                     : result.Message,
                 MessageTypeDefOf.RejectInput,
                 false);

--- a/Source/UI/Settings/Dialog_BWTSettingsJsonPath.cs
+++ b/Source/UI/Settings/Dialog_BWTSettingsJsonPath.cs
@@ -41,14 +41,14 @@ namespace Better_Work_Tab.UI.Settings
             Text.Font = GameFont.Small;
 
             Rect labelRect = new Rect(0f, 46f, inRect.width, 24f);
-            Widgets.Label(labelRect, "JSON file path");
+            Widgets.Label(labelRect, "BWT_Settings_Json_FilePath".Translate());
 
             Rect pathRect = new Rect(0f, 72f, inRect.width, 32f);
             _path = Widgets.TextField(pathRect, _path ?? string.Empty);
 
             Rect hintRect = new Rect(0f, 108f, inRect.width, 28f);
             GUI.color = Color.gray;
-            Widgets.Label(hintRect, "Default folder: " + GenFilePaths.ConfigFolderPath);
+            Widgets.Label(hintRect, "BWT_Settings_Json_DefaultFolder".Translate(GenFilePaths.ConfigFolderPath));
             GUI.color = Color.white;
 
             float buttonWidth = 140f;
@@ -56,12 +56,12 @@ namespace Better_Work_Tab.UI.Settings
             Rect acceptRect = new Rect(inRect.width - buttonWidth, inRect.height - 38f, buttonWidth, 35f);
             Rect openFolderRect = new Rect(cancelRect.xMax + 8f, inRect.height - 38f, buttonWidth, 35f);
 
-            if (Widgets.ButtonText(cancelRect, "Cancel"))
+            if (Widgets.ButtonText(cancelRect, "Cancel".Translate()))
             {
                 Close();
             }
 
-            if (Widgets.ButtonText(openFolderRect, "Open Folder"))
+            if (Widgets.ButtonText(openFolderRect, "BWT_Settings_Json_OpenFolder".Translate()))
             {
                 Application.OpenURL(GenFilePaths.ConfigFolderPath);
             }
@@ -71,7 +71,7 @@ namespace Better_Work_Tab.UI.Settings
                 string resolved = ResolvePath(_path);
                 if (string.IsNullOrWhiteSpace(resolved))
                 {
-                    Messages.Message("Enter a valid JSON file path.", MessageTypeDefOf.RejectInput, false);
+                    Messages.Message("BWT_Settings_Json_InvalidPath".Translate(), MessageTypeDefOf.RejectInput, false);
                     return;
                 }
 

--- a/Source/UI/Settings/WorkTabColorPreviewRenderer.cs
+++ b/Source/UI/Settings/WorkTabColorPreviewRenderer.cs
@@ -154,7 +154,7 @@ namespace Better_Work_Tab.UI.Settings
             WorkGridAnimatedColumnGeometry workColumnGeometry =
                 WorkGridInteractionGeometry.GetAnimatedColumn(workColumn.Value);
             headerRect = workColumnGeometry.HeaderRect;
-            headerLabel = workColumn.Value.Column?.LabelCap ?? "Work";
+            headerLabel = workColumn.Value.Column?.LabelCap ?? "BWT_Settings_Preview_Work".Translate();
             cellText = GetRepresentativeSkillLevel(pawnRow.Value, workColumn.Value);
             Rect pawnScreenRect = layout.GetScreenRect(pawnRow.Value);
             rowRect = Rect.MinMaxRect(gridXMin, pawnScreenRect.y, gridXMax, pawnScreenRect.yMax);
@@ -230,11 +230,11 @@ namespace Better_Work_Tab.UI.Settings
             WorkTypeDef workType = column.SubWorkParent ?? column.Column?.workType;
             if (row.Pawn?.skills == null || workType?.relevantSkills == null || workType.relevantSkills.Count == 0)
             {
-                return "—";
+                return "-";
             }
 
             SkillRecord skill = row.Pawn.skills.GetSkill(workType.relevantSkills[0]);
-            return skill?.Level.ToString() ?? "—";
+            return skill?.Level.ToString() ?? "-";
         }
 
         private static void DrawHeaderTextPreview(Rect rect, string label, Color color)
@@ -303,7 +303,7 @@ namespace Better_Work_Tab.UI.Settings
             GUI.color = Color.white;
             Widgets.Label(
                 new Rect(swatch.xMax + 7f, legend.y, legend.width - 40f, legend.height),
-                "Live preview: " + preview.Label);
+                "BWT_Settings_Preview_Live".Translate(preview.Label));
             GUI.color = oldColor;
             Text.Font = oldFont;
             Text.Anchor = oldAnchor;

--- a/Source/UI/Window_RulesManager.cs
+++ b/Source/UI/Window_RulesManager.cs
@@ -123,9 +123,9 @@ namespace Better_Work_Tab.UI
         public override void DoWindowContents(Rect inRect)
         {
             Text.Font = GameFont.Medium;
-            Widgets.Label(inRect, "Manage Rules");
+            Widgets.Label(inRect, "BWT_ManageRules".Translate());
             Text.Font = GameFont.Small;
-            float titleHeight = Text.CalcHeight("Manage Rules", 0) + 12f;
+            float titleHeight = Text.CalcHeight("BWT_ManageRules".Translate(), 0) + 12f;
 
             Rect contentRect = inRect;
             contentRect.height -= titleHeight;
@@ -214,7 +214,7 @@ namespace Better_Work_Tab.UI
                 GUI.color = Color.gray;
                 var defaultAnchor = Text.Anchor;
                 Text.Anchor = TextAnchor.MiddleCenter;
-                Widgets.Label(outRect, "No rule selected");
+                Widgets.Label(outRect, "BWT_NoRuleSelected".Translate());
                 Text.Anchor = defaultAnchor;
                 GUI.color = oldColor;
                 return;
@@ -321,11 +321,11 @@ namespace Better_Work_Tab.UI
             if (uneditable) GUI.color = Color.gray;
 
             Gender? value = (Gender?)field.GetValue(SelectedRule.Parameters);
-            if (Widgets.ButtonText(valueRect, value?.ToString() ?? "Unassigned", active: !uneditable))
+            if (Widgets.ButtonText(valueRect, value?.ToString() ?? "BWT_Unassigned".Translate(), active: !uneditable))
             {
                 List<FloatMenuOption> enums = new List<FloatMenuOption>()
                 {
-                    new FloatMenuOption("Unassigned", delegate
+                    new FloatMenuOption("BWT_Unassigned".Translate(), delegate
                     {
                         field.SetValue(SelectedRule.Parameters, null);
                         SoundDefOf.Tick_Tiny.PlayOneShotOnCamera();
@@ -360,10 +360,10 @@ namespace Better_Work_Tab.UI
             }
 
             bool missingSavedWorktype = !string.IsNullOrEmpty(parameters.WorktypeString) && worktype == null;
-            string buttonLabel = worktype?.labelShort.CapitalizeFirst() ?? "Unassigned";
+            string buttonLabel = worktype?.labelShort.CapitalizeFirst() ?? "BWT_Unassigned".Translate();
             if (missingSavedWorktype)
             {
-                buttonLabel = $"\"{parameters.WorktypeString}\" (Missing)";
+                buttonLabel = "BWT_MissingSavedValue".Translate(parameters.WorktypeString);
             }
 
             var oldColor = GUI.color;
@@ -373,7 +373,7 @@ namespace Better_Work_Tab.UI
             {
                 List<FloatMenuOption> defOptions = new List<FloatMenuOption>()
                 {
-                    new FloatMenuOption("Unassigned", delegate
+                    new FloatMenuOption("BWT_Unassigned".Translate(), delegate
                     {
                         field.SetValue(parameters, null);
                         parameters.WorktypeString = "";
@@ -409,7 +409,7 @@ namespace Better_Work_Tab.UI
             {
                 List<FloatMenuOption> defOptions = new List<FloatMenuOption>()
                 {
-                    new FloatMenuOption("Unassigned", delegate
+                    new FloatMenuOption("BWT_Unassigned".Translate(), delegate
                     {
                         field.SetValue(parameters, null);
                         parameters.XenotypeString = "";
@@ -437,14 +437,14 @@ namespace Better_Work_Tab.UI
 
             var parameters = SelectedRule.Parameters;
             Tuple<TraitDef, int> trait = (Tuple<TraitDef, int>)field.GetValue(parameters);
-            string buttonLabel = "Unassigned";
+            string buttonLabel = "BWT_Unassigned".Translate();
             if (trait?.Item1 != null)
             {
                 buttonLabel = trait.Item1.DataAtDegree(trait.Item2).LabelCap;
             }
             else if (!string.IsNullOrEmpty(parameters.TraitString))
             {
-                buttonLabel = $"\"{parameters.TraitString}\" (Missing)";
+                buttonLabel = "BWT_MissingSavedValue".Translate(parameters.TraitString);
             }
 
             var oldColor = GUI.color;
@@ -461,7 +461,7 @@ namespace Better_Work_Tab.UI
             {
                 List<FloatMenuOption> list = new List<FloatMenuOption>()
                 {
-                    new FloatMenuOption("Unassigned", delegate
+                    new FloatMenuOption("BWT_Unassigned".Translate(), delegate
                     {
                         field.SetValue(parameters, null);
                         parameters.TraitString = "";
@@ -495,7 +495,7 @@ namespace Better_Work_Tab.UI
 
         private void DrawUnsupportedParameter(Rect rowRect)
         {
-            Widgets.Label(rowRect, "NESTED RULES NOT SUPPORTED");
+            Widgets.Label(rowRect, "BWT_NestedRulesNotSupported".Translate());
         }
 
         /// <summary>
@@ -563,7 +563,7 @@ namespace Better_Work_Tab.UI
 
             rect2.SplitHorizontally(32f, out Rect titleRect, out rect2);
 
-            selectedRuleset.Name = ruleNameBuffer == "" ? "New Ruleset " + (Settings.SavedRulesets?.IndexOf(selectedRuleset) + 1) ?? ruleNameBuffer : ruleNameBuffer;
+            selectedRuleset.Name = ruleNameBuffer == "" ? "BWT_NewRuleset".Translate().ToString() + " " + (Settings.SavedRulesets?.IndexOf(selectedRuleset) + 1) ?? ruleNameBuffer : ruleNameBuffer;
 
             if (uneditable)
             {

--- a/Source/UI/WorkGiverReassignments/SubWorkDrilldownBarRenderer.cs
+++ b/Source/UI/WorkGiverReassignments/SubWorkDrilldownBarRenderer.cs
@@ -144,7 +144,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             }
 
             SubWorkHeaderAffordance.DrawBackBadge(rect);
-            TooltipHandler.TipRegion(rect, "Back to work types. Escape also works.");
+            TooltipHandler.TipRegion(rect, "BWT_SpecificJob_BackToWorkTypes".Translate());
             MouseoverSounds.DoRegion(rect);
 
             Rect labelRect = new Rect(

--- a/Source/UI/WorkGiverReassignments/SubWorkInteractionController.cs
+++ b/Source/UI/WorkGiverReassignments/SubWorkInteractionController.cs
@@ -60,7 +60,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                 ClearPendingSubWorkGesture();
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOrder,
-                    "Specific-job expansion is unavailable while this workload preview owns an unprojected ordering dimension.");
+                    "BWT_Workload_SpecificJobOrderUnavailable".Translate());
                 return false;
             }
 
@@ -345,7 +345,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOrder,
-                    "Specific-job expansion is unavailable while this workload preview owns an unprojected ordering dimension.");
+                    "BWT_Workload_SpecificJobOrderUnavailable".Translate());
                 return;
             }
 

--- a/Source/UI/WorkGiverReassignments/Window_WorkGiverSubMenu.cs
+++ b/Source/UI/WorkGiverReassignments/Window_WorkGiverSubMenu.cs
@@ -490,8 +490,8 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                 sb.Append("\n\n").Append(desc);
             }
 
-            sb.Append("\n\n").Append("Drag to reorder");
-            sb.Append("\n").Append("Hold drag to move; drag out to another work type header to reassign");
+            sb.Append("\n\n").Append("BWT_SpecificJob_DragToReorder".Translate());
+            sb.Append("\n").Append("BWT_SpecificJob_DragToMove".Translate());
 
             return sb.ToString();
         }
@@ -702,12 +702,12 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                 : WorkTabEffectiveStateIds.ForWorkTypeOrder(_pawn, _workType);
             var options = new List<FloatMenuOption>();
             options.Add(new FloatMenuOption(
-                "Clear workload order",
+                "BWT_Workload_ClearSpecificJobOrder".Translate(),
                 () => controller.SetWorkTypeOrderPreviewIntent(
                     key,
                     WorkloadIntent<WorkloadWorkTypeOrderPayload>.Clear)));
             options.Add(new FloatMenuOption(
-                "Remove workload order opinion",
+                "BWT_Workload_LeaveSpecificJobOrderUnchanged".Translate(),
                 () => controller.SetWorkTypeOrderPreviewIntent(
                     key,
                     WorkloadIntent<WorkloadWorkTypeOrderPayload>.NoOpinion)));
@@ -729,7 +729,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             if (currentOrder.IsValid)
             {
                 options.Add(new FloatMenuOption(
-                    "Re-add displayed order to workload",
+                    "BWT_Workload_SaveDisplayedSpecificJobOrder".Translate(),
                     () => controller.SetWorkTypeOrderPreviewIntent(
                         key,
                         WorkloadIntent<WorkloadWorkTypeOrderPayload>.CreateSet(currentOrder))));
@@ -778,7 +778,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             int count = overrides.Count;
             
             Rect textRect = new Rect(footerRect.x + 5f, footerRect.y + 8f, footerRect.width - 40f, 24f);
-            Widgets.Label(textRect, $"Pawns with overrides: {count}");
+            Widgets.Label(textRect, "BWT_SpecificJob_PawnsWithOverrides".Translate(count));
             
             Rect btnRect = new Rect(footerRect.xMax - 30f, footerRect.y + 8f, 24f, 24f);
             if (Widgets.ButtonText(btnRect, "▼"))
@@ -792,7 +792,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             List<FloatMenuOption> options = new List<FloatMenuOption>();
             if (pawns.Count == 0)
             {
-                options.Add(new FloatMenuOption("None", null));
+                options.Add(new FloatMenuOption("BWT_None".Translate(), null));
             }
             else
             {

--- a/Source/UI/WorkGiverReassignments/WorkGiverDragHandler.cs
+++ b/Source/UI/WorkGiverReassignments/WorkGiverDragHandler.cs
@@ -98,7 +98,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                         {
                             WorkTabEffectiveStateRuntime.ReportBlocked(
                                 WorkTabEffectiveStateDimension.SpecificJobOrder,
-                                "Cross-work-type work-giver moves are owned by the live layout service.");
+                                "BWT_Workload_MoveSpecificJobUnavailable".Translate());
                         }
                         else
                         {
@@ -163,7 +163,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                     RestoreOriginalOrder(workGivers);
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.SpecificJobOrder,
-                        "Specific-job ordering requires a valid work-type key and, for local order, a valid pawn.");
+                        "BWT_Workload_SpecificJobOrderTargetMissing".Translate());
                     return;
                 }
 
@@ -176,7 +176,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                         RestoreOriginalOrder(workGivers);
                         WorkTabEffectiveStateRuntime.ReportBlocked(
                             WorkTabEffectiveStateDimension.SpecificJobOrder,
-                            "The current work-giver list does not have unique stable keys.");
+                            "BWT_Workload_SpecificJobOrderInvalid".Translate());
                         return;
                     }
                 }
@@ -186,7 +186,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                     RestoreOriginalOrder(workGivers);
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.SpecificJobOrder,
-                        "The dragged work-giver list changed before its stable key could be projected.");
+                        "BWT_Workload_SpecificJobOrderChanged".Translate());
                     return;
                 }
 
@@ -196,7 +196,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                     RestoreOriginalOrder(workGivers);
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.SpecificJobOrder,
-                        "The active preview provider does not own specific-job ordering.");
+                        "BWT_Workload_SpecificJobOrderUnavailable".Translate());
                     return;
                 }
 
@@ -209,7 +209,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
                         RestoreOriginalOrder(workGivers);
                         WorkTabEffectiveStateRuntime.ReportBlocked(
                             WorkTabEffectiveStateDimension.SpecificJobOrder,
-                            "The dragged work-giver list does not have unique stable keys.");
+                            "BWT_Workload_SpecificJobOrderInvalid".Translate());
                         return;
                     }
                 }

--- a/Source/UI/WorkGiverReassignments/WorkGiverPriorityBoxRenderer.cs
+++ b/Source/UI/WorkGiverReassignments/WorkGiverPriorityBoxRenderer.cs
@@ -60,7 +60,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.Schedule,
-                    "Fluffy's live scheduler owns the current work-giver cell.");
+                    "BWT_Workload_FluffyScheduleUnavailable".Translate());
                 return;
             }
 
@@ -509,7 +509,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
 
             DrawOverrideRingIfVisible(boxRect);
             DrawOverrideResetAnimation(pawn.thingIDNumber, wg.def, boxRect);
-            TooltipHandler.TipRegion(boxRect, "Parent work is disabled. Click the priority box to enable the parent work type; click the gold ring to follow the global sub-work priority again.");
+            TooltipHandler.TipRegion(boxRect, "BWT_SpecificJob_ParentDisabledOverride".Translate());
             if (ShouldHandleInput)
             {
                 HandleParentDisabledOverrideClick(wg, pawn, workType, boxRect, workGiverPriority);
@@ -861,7 +861,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOverride,
-                    "The specific-job preview target is no longer available.");
+                    "BWT_Workload_SpecificJobOrderTargetMissing".Translate());
                 return;
             }
 
@@ -876,12 +876,12 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
             var options = new List<FloatMenuOption>
             {
                 new FloatMenuOption(
-                    "Clear workload priority",
+                    "BWT_Workload_ClearSpecificJobPriority".Translate(),
                     () => controller.SetSpecificJobPreviewIntent(
                         key,
                         WorkloadIntent<WorkloadSpecificPriorityPayload>.Clear)),
                 new FloatMenuOption(
-                    "Remove workload priority opinion",
+                    "BWT_Workload_LeaveSpecificJobPriorityUnchanged".Translate(),
                     () => controller.SetSpecificJobPreviewIntent(
                         key,
                         WorkloadIntent<WorkloadSpecificPriorityPayload>.NoOpinion))
@@ -889,7 +889,7 @@ namespace Better_Work_Tab.UI.WorkGiverReassignments
 
             int priority = WorkPrioritySystem.ClampPriority(displayedPriority);
             options.Add(new FloatMenuOption(
-                "Re-add displayed priority to workload",
+                "BWT_Workload_SaveDisplayedSpecificJobPriority".Translate(),
                 () => controller.SetSpecificJobPreviewIntent(
                     key,
                     WorkloadIntent<WorkloadSpecificPriorityPayload>.CreateSet(

--- a/Source/UI/WorkGrid/Commands/WorkPriorityCommandGateway.cs
+++ b/Source/UI/WorkGrid/Commands/WorkPriorityCommandGateway.cs
@@ -35,8 +35,8 @@ namespace Better_Work_Tab.UI.WorkGrid.Commands
     /// </summary>
     internal static class WorkPriorityCommandGateway
     {
-        private const string ExternalPriorityAuthorityReason =
-            "Better Work Tab is read-only while an external priority authority is active.";
+        private static string ExternalPriorityAuthorityReason =>
+            "BWT_Priority_ReadOnlyExternal".Translate();
 
         private static IWorkGridCommandObserver _observer;
 
@@ -247,7 +247,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Commands
 
             if (WorkTabEffectiveStateRuntime.IsPreviewActive)
             {
-                errorMessage = "Specific-job ordering is blocked in preview because the active Work-tab layout owner cannot consume projected order.";
+                errorMessage = "BWT_Workload_SpecificJobOrderUnavailable".Translate();
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOrder,
                     errorMessage);
@@ -266,7 +266,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Commands
                                 out errorMessage);
             if (!accepted && errorMessage == null)
             {
-                errorMessage = "Invalid work-giver move command.";
+                errorMessage = "BWT_Workload_SpecificJobMoveInvalid".Translate();
             }
 
             Observe(command.Kind, accepted, accepted ? command.WorkGiverDefName : errorMessage);
@@ -345,7 +345,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Commands
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOverride,
-                    "No specific-job keys were available for the requested work type.");
+                    "BWT_Workload_SpecificJobOrderTargetMissing".Translate());
                 return false;
             }
 

--- a/Source/UI/WorkGrid/Interaction/WorkGridContextActionController.cs
+++ b/Source/UI/WorkGrid/Interaction/WorkGridContextActionController.cs
@@ -106,18 +106,18 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             var options = new List<FloatMenuOption>
             {
                 new BWTTutorialFloatMenuOption(
-                    "Insert divider above",
+                    "BWT_Context_InsertDividerAbove".Translate(),
                     () => InsertDividerAbove(pawn),
                     BWTGeneralTutorial.PawnDividerLesson,
                     1,
                     "pawn-divider-insert"),
-                new FloatMenuOption("Insert divider below", () => InsertDividerBelow(pawn)),
+                new FloatMenuOption("BWT_Context_InsertDividerBelow".Translate(), () => InsertDividerBelow(pawn)),
                 // Instrumented like "Change title...": the appearance lesson
                 // teaches both, and this is the one option that is always here.
                 // A pawn whose title cannot be edited would otherwise leave the
                 // lesson pointing at a menu entry that does not exist.
                 new BWTTutorialFloatMenuOption(
-                    "Set background color...",
+                    "BWT_Context_SetBackgroundColor".Translate(),
                     () =>
                     {
                         BWTGeneralTutorial.NotifyPawnAppearanceMenuOptionChosen(editingTitle: false);
@@ -130,7 +130,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             if (PawnTitleUtility.CanEditTitle(pawn))
             {
                 options.Insert(2, new BWTTutorialFloatMenuOption(
-                    "Change title...",
+                    "BWT_Context_ChangeTitle".Translate(),
                     () =>
                 {
                     BWTGeneralTutorial.NotifyPawnAppearanceMenuOptionChosen(editingTitle: true);
@@ -143,7 +143,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
 
             if (PawnOrganizer.API.PawnColorDatabase.TryGetColor(pawn, out _))
             {
-                options.Add(new FloatMenuOption("Clear background color", () =>
+                options.Add(new FloatMenuOption("BWT_Context_ClearBackgroundColor".Translate(), () =>
                 {
                     PawnOrganizer.API.PawnColorDatabase.ClearColor(pawn);
                 }));
@@ -155,7 +155,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             if (LayoutSharingManager.IsFollowing)
             {
                 options.Add(new FloatMenuOption(
-                    $"Copy {pawn.NameShortColored} row position to my layout (stop following)",
+                    "BWT_Context_CopyPawnRow".Translate(pawn.NameShortColored),
                     () => LayoutSharingManager.CopyPawnRowToLocalAndStop(pawn)));
             }
 
@@ -182,7 +182,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             if (pawnKey.IsValid && scope.IsExplicitlyExcluded(pawnKey))
             {
                 options.Add(new FloatMenuOption(
-                    "Membership unavailable: excluded by saved workload scope",
+                    "BWT_Context_MembershipExcluded".Translate(),
                     null));
                 return;
             }
@@ -190,7 +190,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             if (!pawnKey.IsValid || record == null || !record.IsAvailable)
             {
                 options.Add(new FloatMenuOption(
-                    "Membership unavailable: pawn is stale or missing",
+                    "BWT_Context_MembershipPawnUnavailable".Translate(),
                     null));
                 return;
             }
@@ -199,7 +199,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
                 record.Classification == WorkloadMembershipClassification.UnrepresentedNew)
             {
                 options.Add(new FloatMenuOption(
-                    "Include in this application",
+                    "BWT_Context_IncludeInApplication".Translate(),
                     () => TogglePreviewMembership(preview, pawnKey)));
                 return;
             }
@@ -208,7 +208,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
                 record.IsRepresented)
             {
                 options.Add(new FloatMenuOption(
-                    "Exclude from this application",
+                    "BWT_Context_ExcludeFromApplication".Translate(),
                     () => TogglePreviewMembership(preview, pawnKey)));
                 return;
             }
@@ -216,13 +216,13 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             if (record.Classification == WorkloadMembershipClassification.UnchangedOutsideScope)
             {
                 options.Add(new FloatMenuOption(
-                    "Membership unavailable: outside saved workload scope",
+                    "BWT_Context_MembershipOutsideScope".Translate(),
                     null));
                 return;
             }
 
             options.Add(new FloatMenuOption(
-                "Membership unavailable for this pawn",
+                "BWT_Context_MembershipUnavailable".Translate(),
                 null));
         }
 
@@ -256,11 +256,11 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
 
             var options = new List<FloatMenuOption>
             {
-                new FloatMenuOption("Edit...", () =>
+                new FloatMenuOption("BWT_Context_Edit".Translate(), () =>
                 {
                     Find.WindowStack.Add(new Dialog_EditDivider(divider));
                 }),
-                new FloatMenuOption("Delete", () =>
+                new FloatMenuOption("Delete".Translate(), () =>
                 {
                     PawnOrganizerSystem.Instance?.Layout.RemoveDivider(divider);
                     NotifyDividerLayoutChanged();
@@ -271,7 +271,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             if (LayoutSharingManager.IsFollowing)
             {
                 options.Add(new FloatMenuOption(
-                    "Copy this divider to my layout (stop following)",
+                    "BWT_Context_CopyDivider".Translate(),
                     () => LayoutSharingManager.CopyDividerToLocalAndStop(divider)));
             }
 
@@ -294,7 +294,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
                 return;
             }
 
-            if (layout.AddDividerBeforePawn(pawn, "New Divider", Color.gray) != null)
+            if (layout.AddDividerBeforePawn(pawn, "BWT_Dialog_Divider_DefaultName".Translate(), Color.gray) != null)
             {
                 NotifyDividerLayoutChanged();
             }
@@ -316,7 +316,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
                 return;
             }
 
-            if (layout.AddDividerAfterPawn(pawn, "New Divider", Color.gray) != null)
+            if (layout.AddDividerAfterPawn(pawn, "BWT_Dialog_Divider_DefaultName".Translate(), Color.gray) != null)
             {
                 NotifyDividerLayoutChanged();
             }

--- a/Source/UI/WorkGrid/Interaction/WorkGridInteractionRouter.cs
+++ b/Source/UI/WorkGrid/Interaction/WorkGridInteractionRouter.cs
@@ -139,7 +139,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
             {
                 WorkTabEffectiveStateRuntime.ReportBlocked(
                     WorkTabEffectiveStateDimension.SpecificJobOrder,
-                    "Undo and redo of the live WorkGiver layout are unavailable while a workload order preview is active.");
+                    "BWT_Workload_OrderUndoUnavailable".Translate());
                 evt.Use();
                 return true;
             }

--- a/Source/UI/WorkGrid/Interaction/WorkTabPriorityInputHandler.cs
+++ b/Source/UI/WorkGrid/Interaction/WorkTabPriorityInputHandler.cs
@@ -50,7 +50,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
                 {
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.Schedule,
-                        "Fluffy's live scheduler owns this input surface.");
+                        "BWT_Workload_FluffyScheduleUnavailable".Translate());
                     evt.Use();
                     return true;
                 }
@@ -79,7 +79,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Interaction
                 {
                     WorkTabEffectiveStateRuntime.ReportBlocked(
                         WorkTabEffectiveStateDimension.ParentPriority,
-                        "Sleek owns this visible cell and has no preview editor bridge.");
+                        "BWT_Workload_SleekCellUnavailable".Translate());
                     evt.Use();
                     return true;
                 }

--- a/Source/UI/WorkGrid/Projection/WorkTabEffectiveStateRuntime.cs
+++ b/Source/UI/WorkGrid/Projection/WorkTabEffectiveStateRuntime.cs
@@ -282,7 +282,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Projection
 
             ReportBlocked(
                 WorkTabEffectiveStateDimension.ParentPriority,
-                "The active preview provider has no effective-state editor.");
+                "BWT_Workload_PawnCannotChange".Translate());
             return false;
         }
 
@@ -304,7 +304,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Projection
 
             ReportBlocked(
                 WorkTabEffectiveStateDimension.Schedule,
-                "The active preview provider has no typed V2 editor.");
+                "BWT_Workload_HourlyPriorityUnavailable".Translate());
             return false;
         }
 
@@ -663,7 +663,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Projection
             {
                 ReportBlocked(
                     WorkTabEffectiveStateDimension.ManualMode,
-                    "The active preview provider does not own manual mode.");
+                    "BWT_Workload_ModeUnavailable".Translate());
                 return false;
             }
 
@@ -712,7 +712,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Projection
             {
                 ReportBlocked(
                     WorkTabEffectiveStateDimension.ManualMode,
-                    "No live pawn/work-type keys were available for the preview manual-mode edit.");
+                    "BWT_Workload_PawnCannotChange".Translate());
                 return false;
             }
 
@@ -723,7 +723,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Projection
             WorkTabEffectiveStateDimension dimension,
             string reason)
         {
-            string safeReason = reason ?? "unsupported effective-state operation.";
+            string safeReason = reason ?? "BWT_Workload_OperationFailed".Translate();
             IWorkTabEffectiveStateProvider provider = CurrentProvider;
             string diagnosticKey = provider.ProviderId + "@" + provider.Revision + "|" +
                                    dimension + "|" + safeReason;

--- a/Source/UI/WorkGrid/Rendering/WorkTabBodyRenderer.cs
+++ b/Source/UI/WorkGrid/Rendering/WorkTabBodyRenderer.cs
@@ -355,28 +355,27 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             {
                 case WorkloadMembershipClassification.Included:
                     accent = new Color(0.30f, 0.74f, 0.66f, 0.88f);
-                    tooltip = "Workload preview: represented and included.";
+                    tooltip = "BWT_Workload_PawnIncludedTooltip".Translate();
                     break;
                 case WorkloadMembershipClassification.UnrepresentedNew:
                     accent = new Color(0.95f, 0.72f, 0.28f, 0.92f);
                     fill = new Color(0.95f, 0.72f, 0.28f, 0.055f);
-                    tooltip = "Workload preview: new or unrepresented pawn. " +
-                              "Right-click the pawn row to include it in this application.";
+                    tooltip = "BWT_Workload_PawnNewTooltip".Translate();
                     break;
                 case WorkloadMembershipClassification.UnchangedOutsideScope:
                     accent = new Color(0.55f, 0.58f, 0.60f, 0.78f);
                     fill = new Color(0f, 0f, 0f, 0.09f);
-                    tooltip = "Workload preview: outside this workload's scope; unchanged by Apply.";
+                    tooltip = "BWT_Workload_PawnOutsideTooltip".Translate();
                     break;
                 case WorkloadMembershipClassification.ExplicitlyExcluded:
                     accent = new Color(0.82f, 0.36f, 0.36f, 0.92f);
                     fill = new Color(0.70f, 0.16f, 0.16f, 0.07f);
-                    tooltip = "Workload preview: excluded for this application; live values remain unchanged.";
+                    tooltip = "BWT_Workload_PawnExcludedTooltip".Translate();
                     break;
                 case WorkloadMembershipClassification.StaleMissing:
                     accent = new Color(0.68f, 0.38f, 0.38f, 0.82f);
                     fill = new Color(0f, 0f, 0f, 0.08f);
-                    tooltip = "Workload preview: represented by the workload but not currently available.";
+                    tooltip = "BWT_Workload_PawnMissingTooltip".Translate();
                     break;
                 default:
                     return;
@@ -1361,7 +1360,11 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
             Text.Anchor = TextAnchor.MiddleCenter;
             Widgets.Label(arrowRect, arrowChar);
             Text.Anchor = originalAnchor;
-            TooltipHandler.TipRegion(arrowRect, divider.IsCollapsed ? "Expand section" : "Collapse section");
+            TooltipHandler.TipRegion(
+                arrowRect,
+                divider.IsCollapsed
+                    ? "BWT_Divider_ExpandSection".Translate()
+                    : "BWT_Divider_CollapseSection".Translate());
         }
 
         private static void ToggleDividerCollapsed(PawnDivider divider)
@@ -1431,7 +1434,7 @@ namespace Better_Work_Tab.UI.WorkGrid.Rendering
                     {
                         WorkTabEffectiveStateRuntime.ReportBlocked(
                             WorkTabEffectiveStateDimension.SpecificJobOverride,
-                            "Sleek owns this mixed cell and has no preview editor bridge.");
+                            "BWT_Workload_SleekCellUnavailable".Translate());
                         continue;
                     }
 

--- a/Source/UI/Workloads/WorkloadGateway.cs
+++ b/Source/UI/Workloads/WorkloadGateway.cs
@@ -58,7 +58,7 @@ namespace Better_Work_Tab.UI.Workloads
             if (_isPreviewActive?.Invoke() == true)
             {
                 _reportPreviewMessage?.Invoke(
-                    "Finish, Save, Save As, Apply, or Cancel the active workload preview before opening the workload list.");
+                    "BWT_Workload_FinishBeforeOpeningList".Translate());
                 return false;
             }
 
@@ -115,8 +115,8 @@ namespace Better_Work_Tab.UI.Workloads
         private static LegacyWorkloadBackend _legacyBackend;
         private static Workload2Backend _modernBackend;
 
-        private const string NoCurrentGameMessage =
-            "There is no current Better Work Tab game.";
+        private static string NoCurrentGameMessage =>
+            "BWT_Workload_NoCurrentGame".Translate();
 
         private static TResult Dispatch<TResult>(
             Func<LegacyWorkloadBackend, TResult> legacyOperation,
@@ -246,7 +246,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult<WorkloadDescriptor>.Fail(
                     WorkloadDiagnosticCode.NoCurrentGame,
-                    "There is no current Better Work Tab game.");
+                    NoCurrentGameMessage);
             }
 
             return ResolveMode() == WorkloadBackendMode.Legacy
@@ -262,7 +262,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult<WorkloadDescriptor>.Fail(
                     WorkloadDiagnosticCode.NoCurrentGame,
-                    "There is no current Better Work Tab workload backend.");
+                    "BWT_Workload_NotReady".Translate());
             }
 
             // Keep the picker/create surface on the same capture path as the
@@ -314,14 +314,14 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult<WorkloadTemplate>.Fail(
                     WorkloadDiagnosticCode.NoCurrentGame,
-                    "There is no current Better Work Tab game.");
+                    NoCurrentGameMessage);
             }
 
             if (ResolveMode() != WorkloadBackendMode.Modern)
             {
                 return WorkloadOperationResult<WorkloadTemplate>.Fail(
                     WorkloadDiagnosticCode.UnsupportedOperation,
-                    "V2 capture is unavailable while legacy workloads are active.");
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate());
             }
 
             WorkloadOperationResult<WorkloadTemplate> captured =
@@ -341,7 +341,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult<WorkloadTemplate>.Fail(
                     WorkloadDiagnosticCode.InvalidState,
-                    "The captured workload template is empty.");
+                    "BWT_Workload_Empty".Translate());
             }
 
             try
@@ -569,7 +569,7 @@ namespace Better_Work_Tab.UI.Workloads
                 Log.Error("[BWT] Typed workload capture failed.\n" + exception);
                 return WorkloadOperationResult<WorkloadTemplate>.Fail(
                     WorkloadDiagnosticCode.InvalidState,
-                    "The current workload could not be captured with complete typed UI state.");
+                    "BWT_Workload_CaptureFailed".Translate());
             }
         }
 
@@ -651,7 +651,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.SaveTemplate(template, makeCurrent),
                 NoCurrentGame<WorkloadDescriptor>,
                 () => V2Unavailable<WorkloadDescriptor>(
-                    "V2 template storage is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         /// <summary>
@@ -671,7 +671,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult.Fail(
                     WorkloadDiagnosticCode.UnsupportedOperation,
-                    "The requested workload mode is not supported.");
+                    "BWT_Workload_ModeUnavailable".Translate());
             }
 
             WorkloadBackendMode currentMode = ResolveMode();
@@ -685,7 +685,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult.Fail(
                     WorkloadDiagnosticCode.BlockedModeTransition,
-                    "Close the active V2 preview before changing workload mode.");
+                    "BWT_Workload_CloseBeforeModeChange".Translate());
             }
 
             BetterWorkTabSettings settings = BetterWorkTabMod.Settings;
@@ -693,7 +693,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult.Fail(
                     WorkloadDiagnosticCode.NoSettings,
-                    "Better Work Tab settings are not loaded.");
+                    "BWT_Workload_NotReady".Translate());
             }
 
             settings.useLegacyWorkloads = targetMode == WorkloadBackendMode.Legacy;
@@ -716,7 +716,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.BeginPreview(),
                 NoCurrentGame<WorkloadSession>,
                 () => V2Unavailable<WorkloadSession>(
-                    "V2 preview is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadSession> SetV2PreviewSession(WorkloadSession session)
@@ -725,7 +725,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.SetPreviewSession(session),
                 NoCurrentGame<WorkloadSession>,
                 () => V2Unavailable<WorkloadSession>(
-                    "V2 preview is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadSession> AdoptV2PreviewSession(
@@ -748,7 +748,7 @@ namespace Better_Work_Tab.UI.Workloads
             if (ResolveMode() != WorkloadBackendMode.Modern)
             {
                 return V2Unavailable<WorkloadSession>(
-                    "V2 preview rebasing is unavailable while legacy workloads are active.");
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate());
             }
 
             if (receipt == null &&
@@ -790,7 +790,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult<WorkloadSession>.Fail(
                     WorkloadDiagnosticCode.NotFound,
-                    "There is no authoritative rebased V2 preview session to adopt.");
+                    "BWT_Workload_PreviewRefreshFailed".Translate());
             }
 
             // Read the session from the active UI backend. Temporary peer
@@ -805,7 +805,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.EditPreview(edit),
                 NoCurrentGame<WorkloadSession>,
                 () => V2Unavailable<WorkloadSession>(
-                    "V2 preview editing is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadSession> SetV2PreviewState(
@@ -815,7 +815,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.SetPreviewState(projectedState),
                 NoCurrentGame<WorkloadSession>,
                 () => V2Unavailable<WorkloadSession>(
-                    "V2 preview editing is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadSession> ExtendV2PreviewBaseline(
@@ -826,14 +826,14 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 return WorkloadOperationResult<WorkloadSession>.Fail(
                     WorkloadDiagnosticCode.NoCurrentGame,
-                    "There is no current Better Work Tab game.");
+                    NoCurrentGameMessage);
             }
 
             return ResolveMode() == WorkloadBackendMode.Modern
                 ? modern.ExtendPreviewBaseline(candidate, pawn)
                 : WorkloadOperationResult<WorkloadSession>.Fail(
                     WorkloadDiagnosticCode.UnsupportedOperation,
-                    "V2 preview baseline extension is unavailable while legacy workloads are active.");
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate());
         }
 
         internal static WorkloadOperationResult<WorkloadSession> RevertV2Preview()
@@ -842,7 +842,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.RevertPreview(),
                 NoCurrentGame<WorkloadSession>,
                 () => V2Unavailable<WorkloadSession>(
-                    "V2 preview editing is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadPreviewPlan> GetV2PreviewPlan(
@@ -852,7 +852,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.PreviewPlan(decisionKind),
                 NoCurrentGame<WorkloadPreviewPlan>,
                 () => V2Unavailable<WorkloadPreviewPlan>(
-                    "V2 preview planning is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadSemanticDiff> GetV2PreviewDiff()
@@ -861,7 +861,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.PreviewDiff(),
                 NoCurrentGame<WorkloadSemanticDiff>,
                 () => V2Unavailable<WorkloadSemanticDiff>(
-                    "V2 preview diff is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadOperationResult<WorkloadSemanticDiff> GetV2PreviewImpactDiff()
@@ -870,7 +870,7 @@ namespace Better_Work_Tab.UI.Workloads
                 modern => modern.PreviewImpactDiff(),
                 NoCurrentGame<WorkloadSemanticDiff>,
                 () => V2Unavailable<WorkloadSemanticDiff>(
-                    "V2 preview impact diff is unavailable while legacy workloads are active."));
+                    "BWT_Workload_PreviewLegacyUnavailable".Translate()));
         }
 
         internal static WorkloadV2CommitResult CommitV2Apply()
@@ -878,7 +878,7 @@ namespace Better_Work_Tab.UI.Workloads
             return DispatchV2Commit(
                 WorkloadDecisionKind.Apply,
                 modern => modern.CommitApply(),
-                "V2 apply is unavailable while legacy workloads are active.");
+                "BWT_Workload_PreviewLegacyUnavailable".Translate());
         }
 
         internal static WorkloadV2CommitResult CommitV2Update()
@@ -886,7 +886,7 @@ namespace Better_Work_Tab.UI.Workloads
             return DispatchV2Commit(
                 WorkloadDecisionKind.Update,
                 modern => modern.CommitUpdate(),
-                "V2 save is unavailable while legacy workloads are active.");
+                "BWT_Workload_PreviewLegacyUnavailable".Translate());
         }
 
         internal static WorkloadV2CommitResult CommitV2Fork(
@@ -896,7 +896,7 @@ namespace Better_Work_Tab.UI.Workloads
             return DispatchV2Commit(
                 WorkloadDecisionKind.Fork,
                 modern => modern.CommitFork(stableId, label),
-                "V2 fork is unavailable while legacy workloads are active.");
+                "BWT_Workload_PreviewLegacyUnavailable".Translate());
         }
 
         /// <summary>
@@ -1189,6 +1189,11 @@ namespace Better_Work_Tab.UI.Workloads
             Current = this;
         }
 
+        private static string T(string key)
+        {
+            return key.Translate().ToString();
+        }
+
         internal static WorkloadPreviewController Current { get; private set; }
 
         internal static bool IsInspectionActiveForCurrentTab =>
@@ -1358,9 +1363,7 @@ namespace Better_Work_Tab.UI.Workloads
                 string clearMessage = _session?.GetUnsupportedClearMessage() ?? string.Empty;
                 return clearMessage.AnyNonWhitespace()
                     ? clearMessage
-                      : "This workload contains a legacy or unsupported workload-owned " +
-                      "payload. Apply, Save, and Save As are disabled so state cannot be " +
-                      "silently dropped.";
+                      : T("BWT_Workload_UnsupportedData");
             }
         }
 
@@ -1393,7 +1396,7 @@ namespace Better_Work_Tab.UI.Workloads
         internal bool CanForkPreview =>
             IsActive && !IsUnsafePreviewInputBlocked && !HasUnsupportedOwnedPresentationState;
         internal string CommitBlockedMessage => _previewRecoveryBlocked
-            ? "The active preview is recovery-blocked because its committed persistence identity could not be adopted safely. Cancel the preview before retrying."
+            ? T("BWT_Workload_PreviewRefreshFailed")
             : IsMultiplayerCommitInFlight
             ? MultiplayerStatusExplanation
             : HasUnsupportedOwnedPresentationState
@@ -1406,8 +1409,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 if (IsMultiplayerRecoveryBlocked)
                 {
-                    return "Multiplayer workload recovery is required. " +
-                           "The preview is locked until the retained synchronized rollback lease is explicitly resolved." +
+                    return T("BWT_Workload_MultiplayerRecovery") +
                            (_multiplayerCommitMessage.AnyNonWhitespace()
                                ? " " + _multiplayerCommitMessage
                                : string.Empty);
@@ -1415,8 +1417,9 @@ namespace Better_Work_Tab.UI.Workloads
 
                 if (IsMultiplayerCommitInFlight)
                 {
-                    return "Waiting for synchronized workload " +
-                           MultiplayerDecisionLabel(_multiplayerDecision) + "." +
+                    return "BWT_Workload_MultiplayerWaiting"
+                               .Translate(MultiplayerDecisionLabel(_multiplayerDecision))
+                               .ToString() +
                            (_multiplayerCommitMessage.AnyNonWhitespace()
                                ? " " + _multiplayerCommitMessage
                                : string.Empty);
@@ -1424,7 +1427,7 @@ namespace Better_Work_Tab.UI.Workloads
 
                 if (_previewRecoveryBlocked)
                 {
-                    return "The active workload preview is recovery-blocked until its persisted identity is safely adopted or the preview is cancelled.";
+                    return T("BWT_Workload_PreviewRefreshFailed");
                 }
 
                 return _multiplayerCommitMessage ?? string.Empty;
@@ -1437,15 +1440,15 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 if (IsMultiplayerRecoveryBlocked)
                 {
-                    return " • recovery";
+                    return T("BWT_Workload_StatusRecovery");
                 }
 
                 if (IsMultiplayerCommitInFlight)
                 {
-                    return " • syncing";
+                    return T("BWT_Workload_StatusSyncing");
                 }
 
-                return " • preview";
+                return T("BWT_Workload_StatusPreview");
             }
         }
 
@@ -1474,13 +1477,13 @@ namespace Better_Work_Tab.UI.Workloads
             switch (decision)
             {
                 case WorkloadDecisionKind.Apply:
-                    return "apply";
+                    return T("BWT_Workload_ApplyAction");
                 case WorkloadDecisionKind.Update:
-                    return "save";
+                    return T("BWT_Workload_SaveAction");
                 case WorkloadDecisionKind.Fork:
-                    return "Save As";
+                    return T("BWT_Workload_SaveAsAction");
                 default:
-                    return "operation";
+                    return T("BWT_Workload_OperationAction");
             }
         }
 
@@ -1549,10 +1552,7 @@ namespace Better_Work_Tab.UI.Workloads
                 state.TerminalState == WorkloadTransactionTerminalState.RollbackFailed)
             {
                 _multiplayerRecoveryBlocked = true;
-                _multiplayerCommitMessage =
-                    state.TerminalState == WorkloadTransactionTerminalState.RollbackFailed
-                        ? "The synchronized commit retained a rollback lease and requires explicit recovery."
-                        : "The synchronized commit requires rollback acknowledgement.";
+                _multiplayerCommitMessage = T("BWT_Workload_MultiplayerRecovery");
                 SetMessage(MultiplayerStatusExplanation);
             }
         }
@@ -1587,14 +1587,11 @@ namespace Better_Work_Tab.UI.Workloads
                     string failedMessage = _multiplayerCommitMessage;
                     _multiplayerRecoveryBlocked = false;
                     PrepareMultiplayerRetry();
-                    SetMessage(
-                        "Multiplayer workload " +
-                        failedDecision +
-                        " was not committed; the preview is still open. " +
-                        (failedMessage.AnyNonWhitespace()
+                    SetMessage("BWT_Workload_MultiplayerNotSaved".Translate(
+                        failedDecision,
+                        failedMessage.AnyNonWhitespace()
                             ? failedMessage
-                            : "No live or stored workload state was changed.") +
-                        " Retry is available without changing the draft.");
+                            : T("BWT_Workload_NoChangesMade")).ToString());
                     return;
                 case WorkloadMultiplayerCommitState.RollbackFailed:
                     _multiplayerRecoveryBlocked = true;
@@ -1650,9 +1647,7 @@ namespace Better_Work_Tab.UI.Workloads
                 {
                     _previewRecoveryBlocked = true;
                     _multiplayerCommitState = WorkloadMultiplayerCommitState.Failed;
-                    _multiplayerCommitMessage =
-                        "The synchronized " + MultiplayerDecisionLabel(_multiplayerDecision) +
-                        " completed, but the authoritative rebased preview could not be adopted safely.";
+                    _multiplayerCommitMessage = T("BWT_Workload_PreviewRefreshFailed");
                     SetMessage(MultiplayerStatusExplanation);
                     return;
                 }
@@ -1666,8 +1661,7 @@ namespace Better_Work_Tab.UI.Workloads
                 SetMessage(
                     (saveMessage ?? string.Empty).AnyNonWhitespace()
                         ? saveMessage
-                        : "The synchronized " + confirmedDecision +
-                          " was confirmed; the preview remains open.");
+                        : "BWT_Workload_MultiplayerSaved".Translate(confirmedDecision).ToString());
                 return;
             }
 
@@ -1677,8 +1671,7 @@ namespace Better_Work_Tab.UI.Workloads
             {
                 _multiplayerRecoveryBlocked = true;
                 _multiplayerCommitState = WorkloadMultiplayerCommitState.Failed;
-                _multiplayerCommitMessage =
-                    "The synchronized commit succeeded, but the local preview could not be closed safely.";
+                _multiplayerCommitMessage = T("BWT_Workload_MultiplayerApplyCloseFailed");
                 SetMessage(MultiplayerStatusExplanation);
                 return;
             }
@@ -1688,7 +1681,7 @@ namespace Better_Work_Tab.UI.Workloads
             SetMessage(
                 (message ?? string.Empty).AnyNonWhitespace()
                     ? message
-                    : "The synchronized workload operation was confirmed.");
+                    : T("BWT_Workload_MultiplayerConfirmed"));
         }
 
         private void ClearMultiplayerAttempt()
@@ -1788,7 +1781,7 @@ namespace Better_Work_Tab.UI.Workloads
             get
             {
                 return IsActive
-                    ? "Workload preview is active; Alt-click continues through BWT contextual settings."
+                    ? T("BWT_Workload_SettingsStatus")
                     : string.Empty;
             }
         }
@@ -1808,9 +1801,10 @@ namespace Better_Work_Tab.UI.Workloads
             get
             {
                 return PriorityAuthorityBroker.CurrentAuthority == PriorityAuthorityOwner.BetterWorkTab
-                    ? "BWT owns priority data"
-                    : "External priority authority: " +
-                      PriorityAuthorityBroker.CurrentAuthority;
+                    ? T("BWT_Workload_PrioritySourceBWT")
+                    : "BWT_Workload_PrioritySourceExternal"
+                        .Translate(PriorityAuthorityBroker.CurrentAuthority.ToString())
+                        .ToString();
             }
         }
 
@@ -1826,7 +1820,7 @@ namespace Better_Work_Tab.UI.Workloads
                 var blocked = new List<string>();
                 if ((_session.UnsupportedClearDimensions?.Count ?? 0) > 0)
                 {
-                    blocked.Add("explicit clears without typed state");
+                    blocked.Add(T("BWT_Workload_UnsupportedOlderClears"));
                 }
 
                 WorkloadProjectedState[] states =
@@ -1839,22 +1833,24 @@ namespace Better_Work_Tab.UI.Workloads
                     if (WorkloadV2OwnershipResolver.HasLegacyPayload(
                             states[i],
                             WorkloadStateDimension.Schedules) &&
-                        !blocked.Contains("legacy schedules"))
+                        !blocked.Contains(T("BWT_Workload_UnsupportedOlderSchedules")))
                     {
-                        blocked.Add("legacy schedules");
+                        blocked.Add(T("BWT_Workload_UnsupportedOlderSchedules"));
                     }
 
                     if (WorkloadV2OwnershipResolver.HasLegacyPayload(
                             states[i],
                             WorkloadStateDimension.PresentationSettings) &&
-                        !blocked.Contains("legacy presentation settings"))
+                        !blocked.Contains(T("BWT_Workload_UnsupportedOlderDisplay")))
                     {
-                        blocked.Add("legacy presentation settings");
+                        blocked.Add(T("BWT_Workload_UnsupportedOlderDisplay"));
                     }
                 }
                 return blocked.Count == 0
                     ? string.Empty
-                    : "Unsupported dimensions: " + string.Join(", ", blocked.ToArray());
+                    : "BWT_Workload_UnsupportedList"
+                        .Translate(string.Join(", ", blocked.ToArray()))
+                        .ToString();
             }
         }
 
@@ -1878,8 +1874,10 @@ namespace Better_Work_Tab.UI.Workloads
                 }
 
                 return messages.Count == 0
-                    ? "Blocked: workload validation failed."
-                    : "Blocked: " + string.Join(" | ", messages.ToArray());
+                    ? T("BWT_Workload_ValidationFailed")
+                    : "BWT_Workload_ValidationDetails"
+                        .Translate(string.Join(" | ", messages.ToArray()))
+                        .ToString();
             }
         }
 
@@ -1898,8 +1896,7 @@ namespace Better_Work_Tab.UI.Workloads
                 if (IsMultiplayerCommitInFlight)
                 {
                     _multiplayerRecoveryBlocked = true;
-                    _multiplayerCommitMessage =
-                        "The game context changed while synchronized workload state was in flight.";
+                    _multiplayerCommitMessage = T("BWT_Workload_GameChanged");
                     SetMessage(MultiplayerStatusExplanation);
                 }
                 else
@@ -1993,7 +1990,7 @@ namespace Better_Work_Tab.UI.Workloads
                 }
                 catch (Exception exception)
                 {
-                    SetMessage("The workload preview operation failed.");
+                    SetMessage(T("BWT_Workload_OperationFailed"));
                     Log.Error("[BWT] Workload preview lifecycle action failed.\n" + exception);
                 }
 
@@ -2006,7 +2003,7 @@ namespace Better_Work_Tab.UI.Workloads
                     string message = LastMessage;
                     if (!message.AnyNonWhitespace())
                     {
-                        message = "The workload preview operation could not be completed.";
+                        message = T("BWT_Workload_OperationFailed");
                     }
 
                     Messages.Message(message, MessageTypeDefOf.RejectInput, false);
@@ -2073,7 +2070,7 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (WorkloadGateway.CurrentMode != WorkloadBackendMode.Modern)
             {
-                SetMessage("Modern workload preview is unavailable in legacy mode.");
+                SetMessage(T("BWT_Workload_PreviewLegacyUnavailable"));
                 return false;
             }
 
@@ -2127,9 +2124,9 @@ namespace Better_Work_Tab.UI.Workloads
                 return true;
             }
 
-            SetMessage(
-                "Finish, Save, Save As, Apply, or Cancel the active workload preview " +
-                "before " + (operation ?? "changing workloads") + ".");
+            SetMessage("BWT_Workload_FinishPreviewBefore"
+                .Translate(operation ?? T("BWT_Workload_ChangingWorkloads"))
+                .ToString());
             return false;
         }
 
@@ -2137,7 +2134,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (string.IsNullOrEmpty(stableId))
             {
-                SetMessage("The workload stable ID is missing.");
+                SetMessage(T("BWT_Workload_NotFound"));
                 return false;
             }
 
@@ -2165,7 +2162,7 @@ namespace Better_Work_Tab.UI.Workloads
                 return BeginCurrentPreview();
             }
 
-            SetMessage("Selected workload.");
+            SetMessage(T("BWT_Workload_Selected"));
             return true;
         }
 
@@ -2174,7 +2171,7 @@ namespace Better_Work_Tab.UI.Workloads
             descriptor = null;
             if (IsActive)
             {
-                if (!CanLeavePreviewForWorkloadOperation("creating a workload"))
+                if (!CanLeavePreviewForWorkloadOperation(T("BWT_Workload_Creating")))
                 {
                     return false;
                 }
@@ -2197,7 +2194,7 @@ namespace Better_Work_Tab.UI.Workloads
                 return false;
             }
 
-            SetMessage("Created workload " + descriptor.Label + ".");
+            SetMessage("BWT_Workload_Created".Translate(descriptor.Label).ToString());
             return true;
         }
 
@@ -2205,7 +2202,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (string.IsNullOrEmpty(stableId) || string.IsNullOrWhiteSpace(label))
             {
-                SetMessage("A workload name is required.");
+                SetMessage(T("BWT_Workload_NameRequired"));
                 return false;
             }
 
@@ -2213,7 +2210,7 @@ namespace Better_Work_Tab.UI.Workloads
                 StringComparer.Ordinal.Equals(SourceStableId, stableId);
             if (reopenPreview)
             {
-                if (!CanLeavePreviewForWorkloadOperation("renaming this workload"))
+                if (!CanLeavePreviewForWorkloadOperation(T("BWT_Workload_Renaming")))
                 {
                     return false;
                 }
@@ -2236,7 +2233,7 @@ namespace Better_Work_Tab.UI.Workloads
                 }
             }
 
-            SetMessage("Renamed workload.");
+            SetMessage(T("BWT_Workload_Renamed"));
             return true;
         }
 
@@ -2244,7 +2241,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (string.IsNullOrEmpty(stableId))
             {
-                SetMessage("The workload stable ID is missing.");
+                SetMessage(T("BWT_Workload_NotFound"));
                 return false;
             }
 
@@ -2252,7 +2249,7 @@ namespace Better_Work_Tab.UI.Workloads
                 StringComparer.Ordinal.Equals(SourceStableId, stableId);
             if (wasPreviewSource)
             {
-                if (!CanLeavePreviewForWorkloadOperation("deleting this workload"))
+                if (!CanLeavePreviewForWorkloadOperation(T("BWT_Workload_Deleting")))
                 {
                     return false;
                 }
@@ -2267,7 +2264,7 @@ namespace Better_Work_Tab.UI.Workloads
                 return false;
             }
 
-            SetMessage("Deleted workload.");
+            SetMessage(T("BWT_Workload_Deleted"));
             return true;
         }
 
@@ -2278,7 +2275,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (!IsActive)
             {
-                SetMessage("There is no active workload preview.");
+                SetMessage(T("BWT_Workload_NoActivePreview"));
                 return false;
             }
 
@@ -2300,8 +2297,9 @@ namespace Better_Work_Tab.UI.Workloads
             _multiplayerForkStableId = forkStableId ?? string.Empty;
             _multiplayerForkLabel = forkLabel ?? string.Empty;
             _multiplayerPayloadFingerprint = payloadFingerprint;
-            _multiplayerCommitMessage =
-                "The request was created from one immutable preview snapshot.";
+            _multiplayerCommitMessage = "BWT_Workload_MultiplayerWaiting"
+                .Translate(MultiplayerDecisionLabel(decision))
+                .ToString();
 
             WorkloadMultiplayerCommitStatus status =
                 WorkloadGateway.BeginV2MultiplayerCommit(
@@ -2312,8 +2310,7 @@ namespace Better_Work_Tab.UI.Workloads
             if (status == null)
             {
                 _multiplayerCommitState = WorkloadMultiplayerCommitState.Rejected;
-                _multiplayerCommitMessage =
-                    "The multiplayer workload transaction could not be created.";
+                _multiplayerCommitMessage = T("BWT_Workload_MultiplayerStartFailed");
                 SetMessage(MultiplayerStatusExplanation);
                 return false;
             }
@@ -2376,7 +2373,7 @@ namespace Better_Work_Tab.UI.Workloads
                 return false;
             }
 
-            SetMessage("Preview canceled; live work priorities were unchanged.");
+            SetMessage(T("BWT_Workload_PreviewCanceled"));
             return true;
         }
 
@@ -2384,7 +2381,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (!IsActive)
             {
-                SetMessage("There is no active workload preview.");
+                SetMessage(T("BWT_Workload_NoActivePreview"));
                 return false;
             }
 
@@ -2428,15 +2425,10 @@ namespace Better_Work_Tab.UI.Workloads
 
         private bool AdoptRebasedPreview(WorkloadV2CommitResult result)
         {
-            string operationLabel = result?.Report?.DecisionKind == WorkloadDecisionKind.Fork
-                ? "Save As"
-                : "Save";
             if (result == null || result.RebasedSession == null)
             {
                 _previewRecoveryBlocked = true;
-                SetMessage(
-                    "The workload " + operationLabel.ToLowerInvariant() +
-                    " succeeded, but its authoritative rebased preview was not available. Cancel the preview before retrying.");
+                SetMessage(T("BWT_Workload_PreviewRefreshFailed"));
                 return false;
             }
 
@@ -2449,9 +2441,7 @@ namespace Better_Work_Tab.UI.Workloads
                     expectedStableId))
             {
                 _previewRecoveryBlocked = true;
-                SetMessage(
-                    "The workload " + operationLabel.ToLowerInvariant() +
-                    " succeeded, but the persisted identity could not be adopted safely. Cancel the preview before retrying.");
+                SetMessage(T("BWT_Workload_PreviewRefreshFailed"));
                 return false;
             }
 
@@ -2466,7 +2456,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (!IsActive)
             {
-                SetMessage("There is no active workload preview.");
+                SetMessage(T("BWT_Workload_NoActivePreview"));
                 return false;
             }
 
@@ -2477,7 +2467,7 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!HasSemanticDiff)
             {
-                SetMessage("Save is available only when the semantic diff is non-empty.");
+                SetMessage(T("BWT_Workload_NothingToSave"));
                 return false;
             }
 
@@ -2499,7 +2489,7 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!HasSemanticDiff)
             {
-                SetMessage("Save is available only when the semantic diff is non-empty.");
+                SetMessage(T("BWT_Workload_NothingToSave"));
                 return false;
             }
 
@@ -2529,7 +2519,7 @@ namespace Better_Work_Tab.UI.Workloads
         {
             if (!IsActive)
             {
-                SetMessage("There is no active workload preview to fork.");
+                SetMessage(T("BWT_Workload_NoActivePreviewForSaveAs"));
                 return false;
             }
 
@@ -2607,12 +2597,12 @@ namespace Better_Work_Tab.UI.Workloads
                     _hasMultiplayerAttempt)
                 {
                     return _multiplayerCommitMessage + " " +
-                           "Finish, Save, Save As, Apply, or Cancel the active preview " +
-                           "before switching workloads.";
+                           "BWT_Workload_FinishPreviewBefore"
+                               .Translate(T("BWT_Workload_Switching"))
+                               .ToString();
                 }
 
-                return "Finish the active workload preview with Apply, Save As, or Cancel before " +
-                       "switching workloads. Save is available when the workload has changes.";
+                return T("BWT_Workload_FinishBeforeSwitching");
             }
         }
 
@@ -2749,20 +2739,20 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!IsActive || key == null || !key.IsValid)
             {
-                SetMessage("The specific-job preview target is no longer available.");
+                SetMessage(T("BWT_Workload_SpecificJobMissing"));
                 return false;
             }
 
             if (!_session.SourceTemplate.Definition.OwnershipDimensions.Owns(
                     WorkloadStateDimension.SpecificJobOverrides))
             {
-                SetMessage("The active workload does not own specific-job priorities.");
+                SetMessage(T("BWT_Workload_SpecificJobPriorityUnavailable"));
                 return false;
             }
 
             return EditPreviewDraft(
                 draft => draft.SetSpecificPriorityIntent(key, intent),
-                "The specific-job preview could not be changed.");
+                T("BWT_Workload_SpecificJobChangeFailed"));
         }
 
         internal bool SetWorkTypeOrderPreviewIntent(
@@ -2777,20 +2767,20 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!IsActive || key == null || !key.IsValid)
             {
-                SetMessage("The WorkGiver order preview target is no longer available.");
+                SetMessage(T("BWT_Workload_SpecificJobOrderTargetMissing"));
                 return false;
             }
 
             if (!_session.SourceTemplate.Definition.OwnershipDimensions.Owns(
                     WorkloadStateDimension.SpecificJobOrder))
             {
-                SetMessage("The active workload does not own WorkGiver ordering.");
+                SetMessage(T("BWT_Workload_SpecificJobOrderUnavailable"));
                 return false;
             }
 
             return EditPreviewDraft(
                 draft => draft.SetWorkTypeOrderIntent(key, intent),
-                "The WorkGiver order preview could not be changed.");
+                T("BWT_Workload_SpecificJobOrderChangeFailed"));
         }
 
         internal bool SetSchedulePreviewIntent(
@@ -2805,20 +2795,20 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!IsActive || key == null || !key.IsValid)
             {
-                SetMessage("The schedule preview target is no longer available.");
+                SetMessage(T("BWT_Workload_HourlyPriorityMissing"));
                 return false;
             }
 
             if (!_session.SourceTemplate.Definition.OwnershipDimensions.Owns(
                     WorkloadStateDimension.Schedules))
             {
-                SetMessage("The active workload does not own schedules.");
+                SetMessage(T("BWT_Workload_HourlyPriorityUnavailable"));
                 return false;
             }
 
             return EditPreviewDraft(
                 draft => draft.SetScheduleIntent(key, intent),
-                "The schedule preview could not be changed.");
+                T("BWT_Workload_HourlyPriorityChangeFailed"));
         }
 
         private bool EditPreviewDraft(
@@ -2886,21 +2876,21 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!IsActive || pawnKey == null || !pawnKey.IsValid)
             {
-                SetMessage("This pawn cannot be changed in the current preview.");
+                SetMessage(T("BWT_Workload_PawnCannotChange"));
                 return false;
             }
 
             WorkloadMembershipRecord record = GetMembershipSnapshot().Find(pawnKey);
             if (record == null || !record.IsAvailable)
             {
-                SetMessage("This pawn is stale or missing and cannot be included.");
+                SetMessage(T("BWT_Workload_PawnMissing"));
                 return false;
             }
 
             WorkloadScope scope = _session.SourceTemplate.Definition.Scope ?? WorkloadScope.Empty;
             if (scope.IsExplicitlyExcluded(pawnKey))
             {
-                SetMessage("This pawn is explicitly excluded by the saved workload scope.");
+                SetMessage(T("BWT_Workload_PawnNeverIncluded"));
                 return false;
             }
 
@@ -2911,7 +2901,7 @@ namespace Better_Work_Tab.UI.Workloads
                     return false;
                 }
 
-                SetMessage("Pawn included for this application.");
+                SetMessage(T("BWT_Workload_PawnIncluded"));
                 return true;
             }
 
@@ -2922,7 +2912,7 @@ namespace Better_Work_Tab.UI.Workloads
                     return false;
                 }
 
-                SetMessage("Pawn included with its current live values for this application.");
+                SetMessage(T("BWT_Workload_PawnIncludedCurrent"));
                 return true;
             }
 
@@ -2934,11 +2924,11 @@ namespace Better_Work_Tab.UI.Workloads
                     return false;
                 }
 
-                SetMessage("Pawn excluded from this application; its live values remain unchanged.");
+                SetMessage(T("BWT_Workload_PawnExcluded"));
                 return true;
             }
 
-            SetMessage("This pawn is outside the saved workload scope and was left unchanged.");
+            SetMessage(T("BWT_Workload_PawnOutside"));
             return false;
         }
 
@@ -2966,7 +2956,7 @@ namespace Better_Work_Tab.UI.Workloads
             Pawn pawn = ResolvePawn(pawnKey);
             if (pawn == null)
             {
-                SetMessage("The current pawn could not be resolved.");
+                SetMessage(T("BWT_Workload_PawnMissing"));
                 return false;
             }
 
@@ -3083,7 +3073,7 @@ namespace Better_Work_Tab.UI.Workloads
 
             if (!wroteValue)
             {
-                SetMessage("This workload has no supported current-pawn dimension to include.");
+                SetMessage(T("BWT_Workload_PawnNoStoredSettings"));
                 return false;
             }
 
@@ -3112,11 +3102,11 @@ namespace Better_Work_Tab.UI.Workloads
 
             if ((dimensions & WorkloadOwnershipDimensions.PresentationSettings) != 0)
             {
-                values.Add("presentation settings");
+                values.Add(T("BWT_Workload_UnsupportedOlderDisplay"));
             }
 
             return values.Count == 0
-                ? "unsupported state"
+                ? T("BWT_Workload_UnsupportedDataShort")
                 : string.Join(", ", values.ToArray());
         }
 
@@ -3128,7 +3118,7 @@ namespace Better_Work_Tab.UI.Workloads
             _session = session;
             _boundComponent = Verse.Current.Game?.GetComponent<GameComponent_BWTWorldSettings>();
             RebuildProjection(_session.ProjectedState);
-            SetMessage("Preview open; live work priorities are unchanged until Apply.");
+            SetMessage(T("BWT_Workload_PreviewOpened"));
         }
 
         private void RebuildProjection(WorkloadProjectedState projectedState)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,14 +3,13 @@
 ## Fluffy's Work Tab
 
 Better Work Tab includes BWT-owned features and compatibility code inspired by and interoperable with
-[Fluffy's Work Tab](https://github.com/fluffy-mods/WorkTab). This includes the familiar expand-beside
-specific-job presentation, time-based work priorities, and compact top-right controls. Better Work Tab
-uses its own settings, priority stores, column definitions, rendering, and interaction code when Fluffy's
-Work Tab is not installed.
+[Fluffy's Work Tab](https://github.com/fluffy-mods/WorkTab). This includes the expand-beside specific-job
+layout, time-based work priorities, and compact top-right controls. Without Fluffy's Work Tab,
+Better Work Tab uses its own settings, priority stores, column definitions, rendering, and interaction code.
 
-No Fluffy Work Tab imagery, sounds, or other CC BY-SA content are bundled with Better Work Tab. When an
-installed copy of Fluffy Work Tab is detected, BWT may interact with its public/runtime types for
-compatibility and migration, and may display icon textures supplied by that installed copy.
+Better Work Tab does not bundle Fluffy Work Tab imagery, sounds, or other CC BY-SA content. When it
+detects an installed copy of Fluffy Work Tab, BWT may use its public code interfaces for compatibility,
+import compatible settings, and display icon textures from that copy.
 
 Fluffy Work Tab software and documentation are distributed under the MIT License:
 
@@ -34,5 +33,5 @@ Fluffy Work Tab software and documentation are distributed under the MIT License
 The upstream license also applies CC BY-SA 4.0 to its original non-software content. See the
 [upstream license](https://github.com/fluffy-mods/WorkTab/blob/master/LICENSE) for the complete terms.
 
-"Fluffy-style" describes UI inspiration and compatibility. Better Work Tab is not affiliated with or
-endorsed by Fluffy.
+"Fluffy-style" describes UI inspiration and compatibility. Better Work Tab is not affiliated with Fluffy
+or endorsed by Fluffy.


### PR DESCRIPTION
Reviews and rewrites player-facing copy across the README, About metadata, settings, translations, tutorials, Rule Builder, workloads, hourly priorities, and specific-job UI.

Validation completed: RimWorld 1.6 build succeeded. All 12 edited XML files parse. English translation keys are unique. git diff --check passes.